### PR TITLE
refactor: Rename util.cpp to util_numerical.cpp for clarity (Issue #43)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ CXXFLAGS = -g -Wall -std=c++17
 # INCLUDE = -I$(BOOST_DIR)/include
 INCLUDE = 
 CXXSRCS = covariance.cpp max.cpp sub.cpp normal.cpp \
-	random_variable.cpp add.cpp util.cpp gate.cpp \
+	random_variable.cpp add.cpp util_numerical.cpp gate.cpp \
 	parser.cpp ssta.cpp expression.cpp main.cpp
 OBJS = $(CXXSRCS:.cpp=.o) 
 DEPS = $(CXXSRCS:.cpp=.d) 
@@ -40,13 +40,13 @@ TEST_SRCS = ../test/test_randomvariable.cpp ../test/test_normal.cpp \
 	../test/test_main_cli.cpp ../test/test_parser_lexical_cast.cpp \
 	../test/test_parser_tokenizer.cpp ../test/test_exception_unification.cpp \
 	../test/test_gate.cpp ../test/test_ssta_unit.cpp \
-	../test/test_expression_assert_migration.cpp
+	../test/test_expression_assert_migration.cpp ../test/test_util.cpp
 TEST_OBJS = $(TEST_SRCS:.cpp=.o)
 TEST_TARGET = ../test/nhssta_test
 
 # Core library objects (without main.cpp)
 LIB_OBJS = covariance.o max.o sub.o normal.o \
-	random_variable.o add.o util.o gate.o \
+	random_variable.o add.o util_numerical.o gate.o \
 	parser.o ssta.o expression.o
 
 $(TARGET) : $(OBJS) 

--- a/src/covariance.cpp
+++ b/src/covariance.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <memory>
 #include "statistics.hpp"
-#include "util.hpp"
+#include "util_numerical.hpp"
 #include "add.hpp"
 #include "sub.hpp"
 #include "max.hpp"

--- a/src/max.cpp
+++ b/src/max.cpp
@@ -7,7 +7,7 @@
 #include "max.hpp"
 #include "sub.hpp"
 #include "covariance.hpp"
-#include "util.hpp"
+#include "util_numerical.hpp"
 #include "exception.hpp"
 
 namespace RandomVariable {

--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <iomanip>
 #include <string>
-#include "util.hpp"
+#include "util_numerical.hpp"
 #include "ssta.hpp"
 #include "ssta_results.hpp"
 #include "add.hpp"

--- a/src/util_numerical.cpp
+++ b/src/util_numerical.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <ctime>
 #include <cctype>
-#include "util.hpp"
+#include "util_numerical.hpp"
 
 namespace RandomVariable {
 

--- a/src/util_numerical.hpp
+++ b/src/util_numerical.hpp
@@ -1,8 +1,8 @@
 // -*- c++ -*-
 // Author: IWAI Jiro
 
-#ifndef NH_UTIL__H
-#define NH_UTIL__H
+#ifndef NH_UTIL_NUMERICAL__H
+#define NH_UTIL_NUMERICAL__H
 
 #include <string>
 
@@ -15,4 +15,4 @@ namespace RandomVariable {
 
 }
 
-#endif // NH_UTIL__H
+#endif // NH_UTIL_NUMERICAL__H

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+#include "../src/util_numerical.hpp"
+#include <cmath>
+
+using namespace RandomVariable;
+
+class UtilTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Setup code if needed
+    }
+
+    void TearDown() override {
+        // Cleanup code if needed
+    }
+};
+
+// Test MeanMax with negative value (should return 0.0)
+TEST_F(UtilTest, MeanMaxNegativeValue) {
+    double result = MeanMax(-10.0);
+    EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+// Test MeanMax with large positive value (should return the value itself)
+TEST_F(UtilTest, MeanMaxLargePositiveValue) {
+    double result = MeanMax(10.0);
+    EXPECT_DOUBLE_EQ(result, 10.0);
+}
+
+// Test MeanMax with zero
+TEST_F(UtilTest, MeanMaxZero) {
+    double result = MeanMax(0.0);
+    EXPECT_GE(result, 0.0);
+    EXPECT_LE(result, 1.0);
+}
+
+// Test MeanMax with values in range [-5, 5]
+TEST_F(UtilTest, MeanMaxInRange) {
+    // Test a few values in the interpolation range
+    double result1 = MeanMax(-2.5);
+    EXPECT_GE(result1, 0.0);
+    EXPECT_LE(result1, 1.0);
+    
+    double result2 = MeanMax(2.5);
+    EXPECT_GE(result2, 0.0);
+    EXPECT_LE(result2, 5.0);
+    
+    double result3 = MeanMax(1.0);
+    EXPECT_GE(result3, 0.0);
+    EXPECT_LE(result3, 5.0);
+}
+
+// Test MeanPhiMax with negative value (should return 1.0)
+TEST_F(UtilTest, MeanPhiMaxNegativeValue) {
+    double result = MeanPhiMax(-10.0);
+    EXPECT_DOUBLE_EQ(result, 1.0);
+}
+
+// Test MeanPhiMax with large positive value (should return 0.0)
+TEST_F(UtilTest, MeanPhiMaxLargePositiveValue) {
+    double result = MeanPhiMax(10.0);
+    EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+// Test MeanPhiMax with zero
+TEST_F(UtilTest, MeanPhiMaxZero) {
+    double result = MeanPhiMax(0.0);
+    EXPECT_GE(result, 0.0);
+    EXPECT_LE(result, 1.0);
+}
+
+// Test MeanPhiMax with values in range [-5, 5]
+TEST_F(UtilTest, MeanPhiMaxInRange) {
+    // Test a few values in the interpolation range
+    double result1 = MeanPhiMax(-2.5);
+    EXPECT_GE(result1, 0.0);
+    EXPECT_LE(result1, 1.0);
+    
+    double result2 = MeanPhiMax(2.5);
+    EXPECT_GE(result2, 0.0);
+    EXPECT_LE(result2, 1.0);
+    
+    double result3 = MeanPhiMax(1.0);
+    EXPECT_GE(result3, 0.0);
+    EXPECT_LE(result3, 1.0);
+}
+
+// Test MeanMax2 with negative value (should return 1.0)
+TEST_F(UtilTest, MeanMax2NegativeValue) {
+    double result = MeanMax2(-10.0);
+    EXPECT_DOUBLE_EQ(result, 1.0);
+}
+
+// Test MeanMax2 with large positive value (should return a^2)
+TEST_F(UtilTest, MeanMax2LargePositiveValue) {
+    double a = 10.0;
+    double result = MeanMax2(a);
+    EXPECT_DOUBLE_EQ(result, a * a);
+}
+
+// Test MeanMax2 with zero
+TEST_F(UtilTest, MeanMax2Zero) {
+    double result = MeanMax2(0.0);
+    EXPECT_GE(result, 0.0);
+    EXPECT_LE(result, 1.0);
+}
+
+// Test MeanMax2 with values in range [-5, 5]
+TEST_F(UtilTest, MeanMax2InRange) {
+    // Test a few values in the interpolation range
+    double result1 = MeanMax2(-2.5);
+    EXPECT_GE(result1, 0.0);
+    EXPECT_LE(result1, 10.0);
+    
+    double result2 = MeanMax2(2.5);
+    EXPECT_GE(result2, 0.0);
+    EXPECT_LE(result2, 10.0);
+    
+    double result3 = MeanMax2(1.0);
+    EXPECT_GE(result3, 0.0);
+    EXPECT_LE(result3, 10.0);
+}
+
+// Test monotonicity: MeanMax should be monotonic increasing
+TEST_F(UtilTest, MeanMaxMonotonicity) {
+    double a1 = -2.0;
+    double a2 = -1.0;
+    double a3 = 0.0;
+    double a4 = 1.0;
+    double a5 = 2.0;
+    
+    double r1 = MeanMax(a1);
+    double r2 = MeanMax(a2);
+    double r3 = MeanMax(a3);
+    double r4 = MeanMax(a4);
+    double r5 = MeanMax(a5);
+    
+    EXPECT_LE(r1, r2);
+    EXPECT_LE(r2, r3);
+    EXPECT_LE(r3, r4);
+    EXPECT_LE(r4, r5);
+}
+
+// Test boundary values
+TEST_F(UtilTest, MeanMaxBoundaryValues) {
+    double result_minus5 = MeanMax(-5.0);
+    EXPECT_GE(result_minus5, 0.0);
+    
+    double result_plus5 = MeanMax(5.0);
+    EXPECT_LE(result_plus5, 5.0);
+}
+


### PR DESCRIPTION
## 概要

`util.cpp`を`util_numerical.cpp`にリネームし、数値計算系ユーティリティとして明確化しました。テストファーストで進め、すべてのテストがパスすることを確認しています。

## 変更内容

### ファイルリネーム
- `src/util.cpp` → `src/util_numerical.cpp`
- `src/util.hpp` → `src/util_numerical.hpp`

### 理由
現在の`util.cpp`には数値計算系の関数（`MeanMax`, `MeanPhiMax`, `MeanMax2`）のみが含まれており、文字列処理やログ/デバッグ系の関数は存在しません。リネームにより、数値計算系ユーティリティとして明確化しました。

### 更新内容
- すべての`#include "util.hpp"`を`#include "util_numerical.hpp"`に更新
- `Makefile`の`CXXSRCS`と`LIB_OBJS`を更新
- ヘッダーファイルのガード名を更新（`NH_UTIL__H` → `NH_UTIL_NUMERICAL__H`）

### テスト追加
- `test/test_util.cpp`を新規作成
- `MeanMax`, `MeanPhiMax`, `MeanMax2`関数に対する包括的なテストを追加（14テスト）
  - 境界値テスト
  - 範囲内の値のテスト
  - 単調性テスト

## 検証結果

- ✅ 全224テストがパス（以前は210テスト）
- ✅ 既存の機能に影響なし
- ✅ ビルドが正常に完了

## 期待される効果

- **コードの明確化**: 数値計算系ユーティリティとして明確化
- **将来の拡張性**: 文字列処理やログ/デバッグ系のユーティリティを追加する場合、`util_string.cpp`や`util_debug.cpp`として追加可能
- **テストの追加**: `util.cpp`の関数に対する直接的なテストを追加し、品質を向上

## 関連Issue

Closes #43