### PR TITLE
fix: Update README and Makefile for consistency with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ nhsstaは統計的PERT法を実装したプログラムです。nhsstaは以下�
         Makefile             ルートメイクファイル
         .clang-format        コードフォーマット設定
         .clang-tidy          静的解析設定
-       /src/*.[Ch]           ソースファイル
+       /src/*.cpp            ソースファイル
+       /src/*.hpp            内部ヘッダーファイル
        /src/Makefile         ソースビルド設定
+       /include/nhssta/      公開APIヘッダーファイル
        /test/*.cpp           ユニットテスト（Google Test）
        /test/README.md       テストスイートの説明
        /example/*.bench      サンプル.benchデータ
@@ -59,8 +61,8 @@ $ make test
 すべてのテストがパスすると、以下のように表示されます：
 
 ```
-[==========] Running 197 tests from 21 test suites.
-[  PASSED  ] 197 tests.
+[==========] Running 239 tests from 24 test suites.
+[  PASSED  ] 239 tests.
 ```
 
 - 統合テスト（exampleディレクトリのテストスクリプト）を実行する場合：
@@ -94,7 +96,7 @@ $ nhssta -d [.dlibファイル] -b [.benchファイル] [-l] [-c]
 - -l ( --lat ) を指定すると各ノードでのLATの平均、標準偏差を標準出力に
   出力します。
 
-- -c ( -correlation ) ノード間でのLATの相関係数をを標準出力に出力します。
+- -c ( --correlation ) ノード間でのLATの相関係数を標準出力に出力します。
 
 ### 2.3 Exit Codes
 
@@ -196,7 +198,7 @@ make test
 make tidy
 
 # clang-formatでコードを整形（必要に応じて）
-clang-format -i src/YourFile.C
+clang-format -i src/your_file.cpp
 ```
 
 #### ビルド
@@ -204,6 +206,20 @@ clang-format -i src/YourFile.C
 ```bash
 cd src
 make
+```
+
+**注意**: テストをビルドする場合、Google Testのパスを環境変数で指定できます：
+
+```bash
+# macOS (Homebrew以外の場所にインストールした場合)
+export GTEST_DIR=/usr/local/opt/googletest
+cd src
+make test
+
+# Ubuntu/Debianの場合
+export GTEST_DIR=/usr
+cd src
+make test
 ```
 
 ### 4.3 コントリビューション

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,12 @@ DEPS = $(CXXSRCS:.cpp=.d)
 TARGET = nhssta
 
 # Google Test configuration
-GTEST_DIR := /opt/homebrew/opt/googletest
+# GTEST_DIR can be overridden via environment variable
+# Default paths for common installations:
+#   macOS (Homebrew): /opt/homebrew/opt/googletest or /usr/local/opt/googletest
+#   Ubuntu/Debian: /usr
+#   Custom: Set GTEST_DIR environment variable
+GTEST_DIR ?= /opt/homebrew/opt/googletest
 GTEST_INCLUDE := -I$(GTEST_DIR)/include -I../include
 GTEST_LIBS := -L$(GTEST_DIR)/lib -lgtest -lgtest_main -pthread
 

--- a/test/README.md
+++ b/test/README.md
@@ -52,11 +52,11 @@ Tests are compiled into a single test binary:
 
 **Phase 1 (Modern C++ Migration)**: ✅ Complete
 - Boost dependencies removed
-- All 197 tests passing
+- All 239 tests passing
 
 ## Current Test Coverage
 
-- **197 tests** across **21 test suites**
+- **239 tests** across **24 test suites**
 - Unit tests for core components (RandomVariable, Expression, Gate, Parser, Ssta)
 - Integration tests for end-to-end functionality
 - Performance benchmarks


### PR DESCRIPTION
## 概要

実装、README、Makefileの間の乖離を確認し、一貫性を確保するための修正を行いました。

## 変更内容

### README.md
- ディレクトリ構成を更新
  - `/src/*.[Ch]` → `/src/*.cpp` と `/src/*.hpp` に修正
  - `/include/nhssta/` ディレクトリを追加（公開APIヘッダーファイル）
- テスト数を更新: `197 tests from 21 test suites` → `239 tests from 24 test suites`
- clang-format例を更新: `src/YourFile.C` → `src/your_file.cpp`
- コマンドラインオプションのタイポ修正: `-c ( -correlation )` → `-c ( --correlation )`
- GTEST_DIR設定の説明を追加（開発者向けセクション）

### test/README.md
- テスト数を更新: `197 tests from 21 test suites` → `239 tests from 24 test suites`

### src/Makefile
- GTEST_DIRを環境変数で上書き可能に変更（`:=` → `?=`）
- GTEST_DIRのデフォルトパスと環境変数の使い方をコメントで明記

## 検証結果

- ✅ 全239テストがパス（24テストスイート）
- ✅ ビルドが正常に完了
- ✅ リンターエラーなし

## 期待される効果

- **ドキュメントの正確性向上**: 実装とドキュメントの一貫性を確保
- **開発者体験の向上**: GTEST_DIRを環境変数で設定可能にすることで、異なる環境でのビルドが容易に
- **保守性の向上**: テスト数やディレクトリ構成が正確に記載されることで、将来の変更が容易に