### PR TITLE
docs: Update test count in test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -52,11 +52,11 @@ Tests are compiled into a single test binary:
 
 **Phase 1 (Modern C++ Migration)**: ✅ Complete
 - Boost dependencies removed
-- All 239 tests passing
+- All 351 tests passing
 
 ## Current Test Coverage
 
-- **239 tests** across **24 test suites**
+- **351 tests** across **37 test suites**
 - Unit tests for core components (RandomVariable, Expression, Gate, Parser, Ssta)
 - Integration tests for end-to-end functionality
 - Performance benchmarks


### PR DESCRIPTION
## 概要

`test/README.md`のテスト数が古い情報のままになっていたため、実際のテスト実行結果に合わせて更新しました。

## 変更内容

- テスト数: 239 → 351テスト
- テストスイート数: 24 → 37テストスイート

## 確認方法

`make test`を実行すると、以下のように表示されます：
```
[==========] Running 351 tests from 37 test suites.
[  PASSED  ] 351 tests.
```

## 関連

- README.mdのテスト数（351テスト、37テストスイート）と一致するようになりました