### PR TITLE
docs: Update README.md to reflect SmartPtr and RCObject removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,9 @@ make GTEST_DIR=/usr/local/opt/googletest test
 
 ### 4.4 メモリ管理ポリシー
 
-- `RandomVariable` / `Expression` / `Gate` / `Instance` など、実行時グラフを表す主要コンポーネントは **`std::shared_ptr` ベースの薄いハンドル型**に移行済みです
-- 旧来の `SmartPtr` テンプレートは `NH_ENABLE_LEGACY_SMARTPTR=1` を定義した場合のみ利用できます（デフォルト無効）。新規コードでの使用は禁止です
-- `CovarianceMatrix` も同様に `std::shared_ptr` 化されており、共有キャッシュを安全に扱えます
-- 今後は「所有権は標準スマートポインタで明示する」ことを原則とし、例外はドキュメント化してください
+- `RandomVariable` / `Expression` / `Gate` / `Instance` など、実行時グラフを表す主要コンポーネントは **`std::shared_ptr` ベースの薄いハンドル型**を使用しています
+- `CovarianceMatrix` は確率変数間の共分散値を保持するデータ構造で、`std::shared_ptr` を使用して複数の場所から安全に共有・参照できます
+- 所有権は標準スマートポインタで明示することを原則とし、例外はドキュメント化してください
 
 ## 5. 参考文献
 


### PR DESCRIPTION
## 概要

README.mdのメモリ管理ポリシーセクションを、現在のコードベースの状態に合わせて簡潔に更新しました。

## 変更内容

- **不要な記述を削除**: 削除済みの`SmartPtr`と`RCObject`に関する記述を削除（既に存在しないものについて説明する必要はない）
- **表現の改善**: 「共有キャッシュ」という分かりにくい表現を「確率変数間の共分散値を保持するデータ構造で、複数の場所から安全に共有・参照できる」という具体的な説明に変更
- **簡潔化**: 現在の状態のみを説明するように整理

## 背景

以前のPRで`SmartPtr`と`RCObject`は完全に削除されましたが、README.mdに削除されたことを明記する記述が残っていました。既に存在しないものについて説明する必要はないため、現在の状態のみを説明するように簡潔化しました。

## 確認方法

`grep -r "SmartPtr\|smart_ptr\|RCObject" src include`を実行すると、これらのクラスへの参照が見つからないことを確認できます。