### PR TITLE
fix: Align LAT output header with data columns

### DIFF
--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -383,7 +383,7 @@ void Ssta::report_lat() const {
     std::cout << "#" << std::endl;
     std::cout << "# LAT" << std::endl;
     std::cout << "#" << std::endl;
-    std::cout << "#node                     mu             std" << std::endl;
+    std::cout << std::left << std::setw(15) << "#node" << std::right << std::setw(10) << "mu" << std::setw(9) << "std" << std::endl;
     std::cout << "#---------------------------------" << std::endl;
 
     for (const auto& result : results) {


### PR DESCRIPTION
## 概要

LAT出力のヘッダー行（`mu`と`std`）がデータ行とずれていた問題を修正しました。

## 変更内容

- `src/ssta.cpp`の`report_lat()`関数でヘッダー行のフォーマットを修正
- `mu`と`std`を右揃えに変更してデータ行と一致させる

## 修正前

```
#node                     mu             std
#---------------------------------
A                   0.000    0.001
N1                 34.922    3.577
```

## 修正後

```
#node                  mu      std
#---------------------------------
A                   0.000    0.001
N1                 34.922    3.577
```

## 技術的詳細

- データ行のフォーマット: ノード名（左揃え15文字幅）、`mu`（右揃え10文字幅）、`std`（右揃え9文字幅）
- ヘッダー行も同じフォーマットに統一: `#node`（左揃え15文字幅）、`mu`（右揃え10文字幅）、`std`（右揃え9文字幅）

## テスト

- ✅ ビルド成功
- ✅ LAT出力が正しく揃っていることを確認