### PR TITLE
fix: Remove old object files in clean target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -195,6 +195,8 @@ $(TEST_OBJS): ../test/%.o: ../test/%.cpp
 clean :
 	rm -f $(OBJS) $(DEPS) $(TARGET)
 	rm -f $(TEST_OBJS) ../test/nhssta_test
+	# Remove old object files from previous file naming conventions
+	rm -f RandomVariable.o util.o
 
 tags :
 	etags *.hpp *.cpp


### PR DESCRIPTION
## 概要

`make clean`で古いファイル名のオブジェクトファイル（`RandomVariable.o`と`util.o`）が削除されない問題を修正しました。

## 問題

以前のリファクタリングでファイル名が変更されました：
- `RandomVariable.C` → `random_variable.cpp`
- `util.cpp` → `util_numerical.cpp`

しかし、古いファイル名の`.o`ファイル（`RandomVariable.o`と`util.o`）が残っており、Makefileの`clean`ターゲットの`$(OBJS)`には含まれていないため削除されませんでした。

## 変更内容

`src/Makefile`の`clean`ターゲットに、古いファイル名の`.o`ファイルを削除する行を追加：

```makefile
clean :
	rm -f $(OBJS) $(DEPS) $(TARGET)
	rm -f $(TEST_OBJS) ../test/nhssta_test
	# Remove old object files from previous file naming conventions
	rm -f RandomVariable.o util.o
```

## 確認

- ✅ `make clean`実行後、すべての`.o`ファイルが削除されることを確認
- ✅ ビルドが正常に動作することを確認