### PR TITLE
fix: Remove *.gcno files in clean target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -195,6 +195,7 @@ $(TEST_OBJS): ../test/%.o: ../test/%.cpp
 clean :
 	rm -f $(OBJS) $(DEPS) $(TARGET)
 	rm -f $(TEST_OBJS) ../test/nhssta_test
+	@find . -name "*.gcno" -delete 2>/dev/null || true
 
 tags :
 	etags *.hpp *.cpp


### PR DESCRIPTION
## 概要

`make clean`で`*.gcno`ファイル（カバレッジ用のビルド成果物）を削除するように修正しました。

## 変更内容

`src/Makefile`の`clean`ターゲットに、`*.gcno`ファイルの削除を追加：

```makefile
clean :
	rm -f $(OBJS) $(DEPS) $(TARGET)
	rm -f $(TEST_OBJS) ../test/nhssta_test
	@find . -name "*.gcno" -delete 2>/dev/null || true
```

## 設計判断

- **`*.gcno`**: コンパイル時に生成されるビルド成果物 → `clean`で削除
- **`*.gcda`**: 実行時に生成されるデータファイル → `coverage-clean`でのみ削除

これにより：
- `make clean`でビルド成果物が適切に削除される
- カバレッジ計測中に`make clean`を実行しても、`*.gcda`（実行データ）は保持される
- `coverage`ターゲットの動作に影響なし

## 確認

- ✅ `make clean`実行後、`*.gcno`ファイルが削除されることを確認
- ✅ `*.gcda`ファイルは`clean`では削除されないことを確認
- ✅ `coverage-clean`で`*.gcda`と`*.gcno`の両方が削除されることを確認