### PR TITLE
Fix naming conventions: constants, namespace, and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,13 @@
 ### 命名規則
 
 - **クラス名**: PascalCase（例: `Ssta`, `RandomVariable`, `OpADD`）
-- **関数名**: camelCase（例: `getLatResults()`, `read_dlib()`）
+  - 内部実装クラス（Handleパターンの実体クラス）はアンダースコアで始まる/終わる命名も可（例: `_RandomVariable_`, `_Gate_`, `Expression_`）
+- **関数名**: snake_case（例: `read_dlib()`, `read_bench()`, `set_instance_input()`）
+  - 数学関数などはPascalCaseも可（例: `MeanMax()`, `MeanPhiMax()`）
 - **メンバ変数**: snake_case with trailing underscore（例: `is_lat_`, `signals_`, `dlib_`）
 - **ローカル変数**: snake_case（例: `gate_name`, `signal_name`）
-- **定数**: UPPER_SNAKE_CASE（例: `MINIMUM_VARIANCE`）
+- **定数**: UPPER_SNAKE_CASE（例: `MINIMUM_VARIANCE`, `TAB_SIZE`）
+  - static constexpr変数は`k`プレフィックスも可（例: `kCut`, `kDiv`）
 - **ファイル名**: snake_case（例: `random_variable.cpp`, `ssta.hpp`）
 - **ファイル拡張子**: `.cpp`（ソースファイル）、`.hpp`（ヘッダーファイル）
 
@@ -33,8 +36,8 @@
 ### 名前空間
 
 - グローバル名前空間の汚染を避けるため、適切な名前空間を使用します
-- `using namespace` は関数スコープ内でのみ使用可能とします
-- グローバルスコープでの `using namespace std;` は避けます
+- `using namespace` は関数スコープ内またはテストファイル内でのみ使用可能とします
+- グローバルスコープでの `using namespace std;` は避けます（`std::`プレフィックスを使用）
 
 ### コメント
 

--- a/src/covariance.cpp
+++ b/src/covariance.cpp
@@ -75,11 +75,11 @@ static void check_covariance(double& cov, const RandomVariable& a, const RandomV
     double v0 = a->variance();
     double v1 = b->variance();
     double max_cov = sqrt(v0 * v1);
-    if (max_cov < minimum_variance) {
-        if (cov >= minimum_variance) {
+    if (max_cov < MINIMUM_VARIANCE) {
+        if (cov >= MINIMUM_VARIANCE) {
             throw Nh::RuntimeException("check_covariance: covariance " + std::to_string(cov) +
                                        " exceeds maximum possible value " +
-                                       std::to_string(minimum_variance));
+                                       std::to_string(MINIMUM_VARIANCE));
         }
         return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,22 +10,20 @@
 #include <sstream>
 #include <string>
 
-using namespace std;
-
 void usage(const char* first, const char* last) {
-    cerr << "usage: nhssta" << endl;
-    cerr << " -d, --dlib         specifies .dlib file" << endl;
-    cerr << " -b, --bench        specifies .bench file" << endl;
-    cerr << " -l, --lat          prints all LAT data" << endl;
-    cerr << " -c, --correlation  prints correlation matrix of LAT" << endl;
-    cerr << " -h, --help         gives this help" << endl;
+    std::cerr << "usage: nhssta" << std::endl;
+    std::cerr << " -d, --dlib         specifies .dlib file" << std::endl;
+    std::cerr << " -b, --bench        specifies .bench file" << std::endl;
+    std::cerr << " -l, --lat          prints all LAT data" << std::endl;
+    std::cerr << " -c, --correlation  prints correlation matrix of LAT" << std::endl;
+    std::cerr << " -h, --help         gives this help" << std::endl;
     throw Nh::RuntimeException("Invalid command-line arguments");
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 void set_option(int argc, char* argv[], Nh::Ssta* ssta) {
     for (int i = 1; i < argc; i++) {
-        string arg = argv[i];
+        std::string arg = argv[i];
 
         // Handle long options
         if (arg == "--help") {
@@ -36,13 +34,13 @@ void set_option(int argc, char* argv[], Nh::Ssta* ssta) {
             ssta->set_correlation();
         } else if (arg == "--dlib") {
             if (i + 1 < argc) {
-                ssta->set_dlib(string(argv[++i]));
+                ssta->set_dlib(std::string(argv[++i]));
             } else {
                 usage(0, 0);
             }
         } else if (arg == "--bench") {
             if (i + 1 < argc) {
-                ssta->set_bench(string(argv[++i]));
+                ssta->set_bench(std::string(argv[++i]));
             } else {
                 usage(0, 0);
             }
@@ -61,14 +59,14 @@ void set_option(int argc, char* argv[], Nh::Ssta* ssta) {
                     break;
                 case 'd':
                     if (i + 1 < argc) {
-                        ssta->set_dlib(string(argv[++i]));
+                        ssta->set_dlib(std::string(argv[++i]));
                     } else {
                         usage(0, 0);
                     }
                     break;
                 case 'b':
                     if (i + 1 < argc) {
-                        ssta->set_bench(string(argv[++i]));
+                        ssta->set_bench(std::string(argv[++i]));
                     } else {
                         usage(0, 0);
                     }
@@ -104,7 +102,7 @@ std::string get_version_string() {
 int main(int argc, char* argv[]) {
     try {
         // CLI layer: Output version information
-        cerr << get_version_string() << endl;
+        std::cerr << get_version_string() << std::endl;
 
         Nh::Ssta ssta;
         set_option(argc, argv, &ssta);
@@ -114,18 +112,18 @@ int main(int argc, char* argv[]) {
         ssta.report();
 
         // CLI layer: Output success message
-        cerr << "OK" << endl;
+        std::cerr << "OK" << std::endl;
 
     } catch (Nh::Exception& e) {
-        cerr << "error: " << e.what() << endl;
+        std::cerr << "error: " << e.what() << std::endl;
         return 1;
 
-    } catch (exception& e) {
-        cerr << "error: " << e.what() << endl;
+    } catch (std::exception& e) {
+        std::cerr << "error: " << e.what() << std::endl;
         return 2;
 
     } catch (...) {
-        cerr << "error: unknown error" << endl;
+        std::cerr << "error: unknown error" << std::endl;
         return 3;
     }
 

--- a/src/random_variable.cpp
+++ b/src/random_variable.cpp
@@ -126,8 +126,8 @@ double _RandomVariable_::relative_error() {
 }
 
 void _RandomVariable_::check_variance(double& v) {
-    if (fabs(v) < minimum_variance) {
-        v = minimum_variance;
+    if (fabs(v) < MINIMUM_VARIANCE) {
+        v = MINIMUM_VARIANCE;
     }
     if (v < 0.0) {
         throw Nh::RuntimeException("RandomVariable: negative variance");

--- a/src/random_variable.hpp
+++ b/src/random_variable.hpp
@@ -11,7 +11,7 @@
 
 namespace RandomVariable {
 
-const double minimum_variance = 1.0e-6;
+const double MINIMUM_VARIANCE = 1.0e-6;
 
 // Backward compatibility: keep Exception as alias to Nh::RuntimeException
 // This will be removed in a later phase

--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -176,7 +176,7 @@ void Ssta::read_bench_input(Parser& parser) {
     }
     inputs_.insert(signal_name);
 
-    Normal in(0.0, ::RandomVariable::minimum_variance);  //////
+    Normal in(0.0, ::RandomVariable::MINIMUM_VARIANCE);  //////
     in->set_name(signal_name);
     signals_[signal_name] = in;
 
@@ -293,7 +293,7 @@ void Ssta::connect_instances() {
 
 // treat ck of dff as input
 void Ssta::set_dff_out(const std::string& out_signal_name) {
-    Normal in(0.0, ::RandomVariable::minimum_variance);  //////
+    Normal in(0.0, ::RandomVariable::MINIMUM_VARIANCE);  //////
     auto gi = gates_.find("dff");
     Gate dff = gi->second;
 

--- a/src/util_numerical.cpp
+++ b/src/util_numerical.cpp
@@ -144,12 +144,12 @@ double mean_max2_tab[] = {
 
 /* ------------------------------- */
 
-static double cut = 5.0;
-static double div = cut / 100.0;
+static constexpr double kCut = 5.0;
+static constexpr double kDiv = kCut / 100.0;
 static constexpr int TAB_SIZE = 201;  // Array size: -5 to 5 with 0.05 step
 
 static void set_range(double a, int& lower, int& upper) {
-    double len = (a + cut) / div;
+    double len = (a + kCut) / kDiv;
     lower = int(floor(len));
     upper = int(ceil(len));
     // Clamp to valid array bounds
@@ -159,10 +159,10 @@ static void set_range(double a, int& lower, int& upper) {
 }
 
 double MeanMax(double a) {
-    if (a < -cut) {
+    if (a < -kCut) {
         return 0.0;
     }
-    if (cut < a) {
+    if (kCut < a) {
         return a;
     }
     int l = 0;
@@ -173,10 +173,10 @@ double MeanMax(double a) {
 }
 
 double MeanPhiMax(double a) {
-    if (a < -cut) {
+    if (a < -kCut) {
         return 1.0;
     }
-    if (cut < a) {
+    if (kCut < a) {
         return 0.0;
     }
     int l = 0;
@@ -187,10 +187,10 @@ double MeanPhiMax(double a) {
 }
 
 double MeanMax2(double a) {
-    if (a < -cut) {
+    if (a < -kCut) {
         return 1.0;
     }
-    if (cut < a) {
+    if (kCut < a) {
         return a * a;
     }
     int l = 0;

--- a/test/test_normal.cpp
+++ b/test/test_normal.cpp
@@ -62,6 +62,7 @@ TEST_F(NormalTest, VarianceCalculation) {
 
 // Test Normal with minimum variance
 TEST_F(NormalTest, MinimumVariance) {
-    Normal n(0.0, minimum_variance);
-    EXPECT_DOUBLE_EQ(n->variance(), minimum_variance);
+    using namespace RandomVariable;
+    Normal n(0.0, MINIMUM_VARIANCE);
+    EXPECT_DOUBLE_EQ(n->variance(), MINIMUM_VARIANCE);
 }


### PR DESCRIPTION
## 概要

CONTRIBUTING.mdの命名規則と実際のコードの不一致を修正し、命名規則を統一しました。

## 変更内容

### Phase 1: 定数の命名修正
- `minimum_variance` → `MINIMUM_VARIANCE`に変更（UPPER_SNAKE_CASE）
- 影響ファイル: `src/random_variable.hpp`, `src/random_variable.cpp`, `src/covariance.cpp`, `src/ssta.cpp`, `test/test_normal.cpp`

### Phase 2: グローバル名前空間の修正
- `src/main.cpp`の`using namespace std;`を削除
- すべての`std`名前空間の要素に`std::`プレフィックスを追加
- `cerr`, `endl`, `string`, `exception`を修正

### Phase 3: static変数の命名修正
- `cut`, `div` → `kCut`, `kDiv`に変更（`constexpr`も追加）
- 影響ファイル: `src/util_numerical.cpp`

### Phase 4: ドキュメントの更新
- `CONTRIBUTING.md`の命名規則を実際のコードに合わせて更新
- 内部クラス名の命名規則を追加（`_RandomVariable_`など）
- 関数名の命名規則をsnake_caseに統一
- static constexpr変数の命名規則を追加（`k`プレフィックス）
- 名前空間の使用規則を更新（テストファイルでの使用を許可）

## テスト結果

- ✅ すべての333テストがPASS
- ✅ ビルド成功

## 影響範囲

- 定数名の変更: 内部実装のみ（APIの変更なし）
- 名前空間の修正: `main.cpp`のみ（CLI層）
- static変数の変更: `util_numerical.cpp`のみ（内部実装）
- ドキュメントの更新: 命名規則の明確化

## 関連Issue

命名規則の統一とドキュメントの更新