### PR TITLE
fix: Ssta::check() throws ConfigurationException instead of base Exception

### DIFF
--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -39,7 +39,7 @@ void Ssta::check() {
     }
 
     if (!error_msg.empty()) {
-        throw Nh::Exception("error: " + error_msg);
+        throw Nh::ConfigurationException(error_msg);
     }
 }
 

--- a/test/test_coverage_gaps.cpp
+++ b/test/test_coverage_gaps.cpp
@@ -236,12 +236,12 @@ TEST_F(CoverageGapsTest, SstaCheckMissingDlib) {
     ssta.set_bench("../example/ex4.bench");
     // dlib not set
 
-    EXPECT_THROW(ssta.check(), Exception);
+    EXPECT_THROW(ssta.check(), Nh::ConfigurationException);
 
     try {
         ssta.check();
-        FAIL() << "Expected Exception was not thrown";
-    } catch (const Exception& e) {
+        FAIL() << "Expected ConfigurationException was not thrown";
+    } catch (const Nh::ConfigurationException& e) {
         std::string msg = e.what();
         EXPECT_NE(msg.find("-d"), std::string::npos);
     }
@@ -253,12 +253,12 @@ TEST_F(CoverageGapsTest, SstaCheckMissingBench) {
     ssta.set_dlib("../example/ex4_gauss.dlib");
     // bench not set
 
-    EXPECT_THROW(ssta.check(), Exception);
+    EXPECT_THROW(ssta.check(), Nh::ConfigurationException);
 
     try {
         ssta.check();
-        FAIL() << "Expected Exception was not thrown";
-    } catch (const Exception& e) {
+        FAIL() << "Expected ConfigurationException was not thrown";
+    } catch (const Nh::ConfigurationException& e) {
         std::string msg = e.what();
         EXPECT_NE(msg.find("-b"), std::string::npos);
     }
@@ -269,12 +269,12 @@ TEST_F(CoverageGapsTest, SstaCheckMissingBoth) {
     Ssta ssta;
     // Both dlib and bench not set
 
-    EXPECT_THROW(ssta.check(), Exception);
+    EXPECT_THROW(ssta.check(), Nh::ConfigurationException);
 
     try {
         ssta.check();
-        FAIL() << "Expected Exception was not thrown";
-    } catch (const Exception& e) {
+        FAIL() << "Expected ConfigurationException was not thrown";
+    } catch (const Nh::ConfigurationException& e) {
         std::string msg = e.what();
         EXPECT_NE(msg.find("-d"), std::string::npos);
         EXPECT_NE(msg.find("-b"), std::string::npos);

--- a/test/test_ssta_unit.cpp
+++ b/test/test_ssta_unit.cpp
@@ -544,8 +544,8 @@ TEST_F(SstaUnitTest, CheckMethodDoesNotCallExit) {
     Ssta test_ssta;
     test_ssta.set_dlib("");  // Empty dlib to trigger error
 
-    // Should throw exception instead of calling exit()
-    EXPECT_THROW({ test_ssta.check(); }, Nh::Exception);
+    // Should throw ConfigurationException instead of calling exit()
+    EXPECT_THROW({ test_ssta.check(); }, Nh::ConfigurationException);
 }
 
 TEST_F(SstaUnitTest, PureLogicFunctionsDoNotDependOnOutputFlags) {


### PR DESCRIPTION
## 概要

`Ssta::check()`メソッドが、アーキテクチャドキュメント（`docs/architecture.md`）の例外設計ポリシーに従って`Nh::ConfigurationException`を投げるように修正しました。

## 変更内容

### 実装の修正
- `src/ssta.cpp`: `Ssta::check()`が`Nh::ConfigurationException`を投げるように変更
- 不要な`"error: "`プレフィックスを削除（`ConfigurationException`が自動的に追加）

### テストの更新
- `test/test_ssta_unit.cpp`: `CheckMethodDoesNotCallExit`テストを更新
- `test/test_coverage_gaps.cpp`: 3つのテストケースを更新
  - `SstaCheckMissingDlib`
  - `SstaCheckMissingBench`
  - `SstaCheckMissingBoth`

## 修正前後の比較

**修正前:**
```cpp
throw Nh::Exception("error: " + error_msg);
```

**修正後:**
```cpp
throw Nh::ConfigurationException(error_msg);
```

## 検証結果

- ✅ すべてのテストがパス（355テスト）
- ✅ エラーメッセージが正しく表示されることを確認
- ✅ アーキテクチャドキュメントとの整合性を確認

## 関連

Fixes #95