### PR TITLE
fix: Remove dead method declarations from Ssta class header

### DIFF
--- a/include/nhssta/ssta.hpp
+++ b/include/nhssta/ssta.hpp
@@ -124,10 +124,6 @@ class Ssta {
 
     void node_error(const std::string& head, const std::string& signal_name) const;
 
-    void report_lat() const;
-    void report_correlation() const;
-    void print_line() const;
-
     ////
 
     // Use unordered_map for better performance (O(1) average vs O(log n) for map)


### PR DESCRIPTION
## 概要

`include/nhssta/ssta.hpp`から、実装が削除されたメソッドの宣言を削除しました。

## 変更内容

以下の3つのメソッド宣言を削除：
- `report_lat() const`
- `report_correlation() const`
- `print_line() const`

これらのメソッドは、PR #94でI/O分離のリファクタリング時に実装が削除されましたが、ヘッダーファイルの宣言が残っていました。

## 影響

- ✅ コードの一貫性が向上
- ✅ デッドコードが削除され、将来の開発者の混乱を防止
- ✅ コンパイルエラーなし
- ✅ すべてのテストがパス（355テスト）

## 関連

Fixes #96