### PR TITLE
refactor: Remove Parser dependency from Ssta header using forward declaration

### DIFF
--- a/include/nhssta/ssta.hpp
+++ b/include/nhssta/ssta.hpp
@@ -16,7 +16,10 @@
 #include <nhssta/ssta_results.hpp>
 
 #include "../src/gate.hpp"
-#include "../src/parser.hpp"
+
+// Forward declaration for Parser (internal implementation detail)
+// Parser is defined in global namespace in src/parser.hpp
+class Parser;
 
 namespace Nh {
 

--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "add.hpp"
+#include "parser.hpp"
 #include "util_numerical.hpp"
 
 namespace Nh {


### PR DESCRIPTION
## 概要

`include/nhssta/ssta.hpp`から`Parser`への直接依存を削除し、前方宣言を使用するように変更しました。

## 変更内容

### ヘッダーファイルの変更
- `include/nhssta/ssta.hpp`: `#include "../src/parser.hpp"`を削除し、前方宣言に置き換え

### 実装ファイルの変更
- `src/ssta.cpp`: `parser.hpp`のincludeを追加（実装で必要）

## 効果

- ✅ 公開API（`include/nhssta/`）と内部実装（`src/`）の結合度が低下
- ✅ 依存性逆転の原則（DIP）への準拠が向上
- ✅ コンパイルエラーなし
- ✅ すべてのテストがパス（355テスト）

## Gate依存について

`Gate`は`std::unordered_map<std::string, Gate>`として使用されているため、完全な型定義が必要です。前方宣言では解決できません。

`Gate`への依存削減は、以下のいずれかの方法で将来的に対応可能です：
- `Gate`を`include/nhssta/`に移動（公開APIの一部として扱う）
- Pimplパターンの使用
- `Gate`への依存を削減する設計変更

## 関連

Fixes #97