### PR TITLE
refactor: Remove remaining exception aliases from internal implementation files

### DIFF
--- a/docs/exception_migration_plan.md
+++ b/docs/exception_migration_plan.md
@@ -1,46 +1,66 @@
 # 例外クラス統一化の移行計画
 
-## 現在の状況
+**最終更新**: 2025-11-24
+**状態**: ✅ 完了
 
-以下の例外クラスが使用されています：
+## 移行完了
+
+すべての例外エイリアスが削除され、コードベース全体で統一された`Nh::Exception`階層が使用されています。
+
+### 削除されたエイリアス
+
+1. ✅ `Ssta::exception` - Sstaクラス内（Issue #99で削除）
+2. ✅ `Parser::exception` - Parserクラス内（Issue #99で削除）
+3. ✅ `Gate::exception` - Gateクラス内（公開API: Issue #99、内部実装: Issue #107で削除）
+4. ✅ `RandomVariable::Exception` - RandomVariable名前空間内（Issue #99で削除）
+5. ✅ `SmartPtrException` - SmartPtrクラス（削除済み）
+6. ✅ `ExpressionException` - Expressionクラス（Issue #107で削除）
+
+### 現在の状況（過去の記録）
+
+以下の例外クラスが使用されていました（すべて削除済み）：
 1. `Ssta::exception` - Sstaクラス内
 2. `Parser::exception` - Parserクラス内
 3. `Gate::exception` - Gateクラス内
 4. `RandomVariable::Exception` - RandomVariable名前空間内
 5. `SmartPtrException` - SmartPtrクラス
 6. `ExpressionException` - Expressionクラス
-7. `Nh::Exception` - 統一例外クラス（既に存在、Normal.Cで使用）
+7. `Nh::Exception` - 統一例外クラス（現在も使用中）
 
-## 移行計画
+## 移行計画（完了）
 
-### Phase 1: Parser::exception → Nh::ParseException / Nh::FileException
+### Phase 1: Parser::exception → Nh::ParseException / Nh::FileException ✅
 - `Parser::checkFile()` → `Nh::FileException`
 - `Parser::checkTermination()` → `Nh::ParseException`
 - `Parser::unexpectedToken_()` → `Nh::ParseException`
 - `Ssta::read_dlib()`と`Ssta::read_bench()`のキャッチ節を更新
 
-### Phase 2: Gate::exception → Nh::RuntimeException
+### Phase 2: Gate::exception → Nh::RuntimeException ✅
 - `_Gate_::delay()` → `Nh::RuntimeException`
 - `_Instance_::output()` → `Nh::RuntimeException`
 - `Ssta::read_bench()`のキャッチ節を更新
 
-### Phase 3: RandomVariable::Exception → Nh::RuntimeException
+### Phase 3: RandomVariable::Exception → Nh::RuntimeException ✅
 - `_RandomVariable_::check_variance()` → `Nh::RuntimeException`
 - `_Normal_`コンストラクタ → `Nh::RuntimeException`
 - `Ssta::read_bench()`と`Ssta::report()`のキャッチ節を更新
 
-### Phase 4: SmartPtrException → Nh::RuntimeException
+### Phase 4: SmartPtrException → Nh::RuntimeException ✅
 - `SmartPtr::operator SmartPtr<U>()` → `Nh::RuntimeException`
 - `Ssta::read_bench()`と`Ssta::report()`のキャッチ節を更新
 
-### Phase 5: Ssta::exception → Nh::Exception / Nh::RuntimeException
+### Phase 5: Ssta::exception → Nh::Exception / Nh::RuntimeException ✅
 - `Ssta::node_error()` → `Nh::RuntimeException`
 - `Ssta::connect_instances()` → `Nh::RuntimeException`
 - `main.C`のキャッチ節を更新
 
-### Phase 6: ExpressionException → Nh::RuntimeException
+### Phase 6: ExpressionException → Nh::RuntimeException ✅
 - `Expression.C`のすべてのthrow → `Nh::RuntimeException`
 - 注意: ExpressionExceptionはassert(0)を含むため、慎重に扱う
+
+### Phase 7: 内部実装ファイルのエイリアス削除 ✅（Issue #107）
+- `src/gate.hpp`から`Gate::exception`エイリアスを削除
+- `src/expression.hpp`から`ExpressionException`エイリアスを削除
 
 ## テスト戦略
 

--- a/src/expression.hpp
+++ b/src/expression.hpp
@@ -13,11 +13,6 @@
 
 ////////////////////
 
-// Backward compatibility: keep ExpressionException as alias to Nh::RuntimeException
-// This will be removed in a later phase
-// Note: ExpressionException originally had assert(0), but we remove it for unified exception
-// handling
-using ExpressionException = Nh::RuntimeException;
 
 class Expression_;
 

--- a/src/gate.hpp
+++ b/src/gate.hpp
@@ -85,9 +85,6 @@ class _Gate_ {
 // - Storing as member variable creates ownership relationship
 class Gate {
    public:
-    // Backward compatibility: keep exception as alias to Nh::RuntimeException
-    // This will be removed in a later phase
-    using exception = Nh::RuntimeException;
     Gate();
     explicit Gate(std::shared_ptr<_Gate_> body);
 


### PR DESCRIPTION
## 概要

内部実装ファイル（`src/`）に残存していた例外エイリアスを削除し、例外統一化の移行計画を完了しました。

## 変更内容

### 削除したエイリアス
- `src/gate.hpp:90`: `Gate::exception` → `Nh::RuntimeException`
- `src/expression.hpp:20`: `ExpressionException` → `Nh::RuntimeException`

### ドキュメント更新
- `docs/exception_migration_plan.md`: 移行完了を記録し、Phase 7を追加

## 現状

- これらのエイリアスは実際のコードでは使用されていませんでした（コメントやドキュメントにのみ言及）
- Issue #99で公開API（`include/nhssta/`）のエイリアスは削除済み
- 今回の変更で内部実装ファイルのエイリアスも削除し、コードベース全体で統一されました

## 効果

- ✅ **完全な一貫性**: コードベース全体で統一された`Nh::Exception`階層のみを使用
- ✅ **明確性**: 新しい開発者が混乱しない
- ✅ **保守性**: 例外命名体系が完全に統一され、保守が容易に
- ✅ すべてのテストがパス（351テスト）

## 関連

- Issue #99: Remove backward compatibility exception aliases（公開APIのエイリアス削除）
- `docs/exception_migration_plan.md`: 例外統一化の移行計画が完了

Fixes #107