### PR TITLE
docs: Update test counts and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ $ make test
 すべてのテストがパスすると、以下のように表示されます：
 
 ```
-[==========] Running 333 tests from 34 test suites.
-[  PASSED  ] 333 tests.
+[==========] Running 351 tests from 38 test suites.
+[  PASSED  ] 351 tests.
 ==========================================
 Running integration tests...
 ==========================================

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,9 @@ nhssta/
 ├── include/nhssta/          # 公開APIヘッダー
 │   ├── ssta.hpp
 │   ├── exception.hpp
-│   └── ssta_results.hpp
+│   ├── ssta_results.hpp
+│   ├── gate.hpp
+│   └── net_line.hpp
 ├── src/                     # 実装ファイル
 │   ├── ssta.cpp
 │   ├── gate.cpp
@@ -127,8 +129,12 @@ nhssta/
 ## 関連ファイル
 
 - `include/nhssta/ssta.hpp`: Sstaクラスの定義
+- `include/nhssta/gate.hpp`: Gateクラスの定義（公開API）
+- `include/nhssta/net_line.hpp`: NetLineクラスの定義（公開API）
+- `include/nhssta/exception.hpp`: 例外クラス階層の定義
+- `include/nhssta/ssta_results.hpp`: SSTA結果データ構造の定義
 - `src/ssta.cpp`: Sstaクラスの実装
-- `src/gate.hpp`, `src/gate.cpp`: GateとInstanceの実装
+- `src/gate.cpp`: GateとInstanceの実装
 - `src/random_variable.hpp`, `src/random_variable.cpp`: RandomVariableの実装
 - `src/parser.hpp`, `src/parser.cpp`: Parserの実装
 - `src/main.cpp`: CLIエントリーポイント

--- a/test/README.md
+++ b/test/README.md
@@ -52,11 +52,11 @@ Tests are compiled into a single test binary:
 
 **Phase 1 (Modern C++ Migration)**: ✅ Complete
 - Boost dependencies removed
-- All 333 tests passing
+- All 351 tests passing
 
 ## Current Test Coverage
 
-- **333 tests** across **34 test suites**
+- **351 tests** across **38 test suites**
 - Unit tests for core components (RandomVariable, Expression, Gate, Parser, Ssta)
 - Integration tests for end-to-end functionality
 - Performance benchmarks


### PR DESCRIPTION
## 概要

実装、Makefile、READMEの乖離を修正しました。

## 変更内容

### テスト数の更新
- **README.md**: 333 tests from 34 suites → **351 tests from 38 suites**
- **test/README.md**: テスト数を現在の状態に更新

### 公開APIドキュメントの更新
- **docs/architecture.md**: 公開APIヘッダーリストに以下を追加
  - `gate.hpp`（Issue #97で公開APIに移動）
  - `net_line.hpp`（Issue #98で公開APIに移動）
- **docs/architecture.md**: Gate実装の場所を修正
  - 旧: `src/gate.hpp`, `src/gate.cpp`
  - 新: `include/nhssta/gate.hpp`（定義）、`src/gate.cpp`（実装）

## 背景

最近のリファクタリング（Issue #97, #98）により、`Gate`と`NetLine`が公開API（`include/nhssta/`）に移動されましたが、ドキュメントが更新されていませんでした。また、テスト数も実際の状態と乖離していました。

## 確認

- ✅ 実際のテスト実行結果: 351 tests from 38 test suites
- ✅ 公開APIヘッダー: exception.hpp, gate.hpp, net_line.hpp, ssta.hpp, ssta_results.hpp
- ✅ Gate実装: include/nhssta/gate.hpp（定義）、src/gate.cpp（実装）

## 関連

- Issue #97: Ssta class depends on internal implementation details
- Issue #98: NetLineBody and NetLine should be extracted from Ssta class