### PR TITLE
fix: rename checkSepalator to checkSeparator

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -48,9 +48,9 @@ void Parser::checkFile() {
     }
 }
 
-void Parser::checkSepalator(char sepalator) {
+void Parser::checkSeparator(char separator) {
     checkTermination();
-    if ((*token_)[0] != sepalator) {
+    if ((*token_)[0] != separator) {
         unexpectedToken_(*token_);
     }
     pre_ = *token_++;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -65,7 +65,7 @@ class Parser {
     }
 
    public:
-    void checkSepalator(char sepalator);
+    void checkSeparator(char separator);
     void checkEnd();
     void unexpectedToken();
     const std::string& getFileName() const {

--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -99,7 +99,7 @@ void Ssta::read_dlib_line(Parser& parser) {
         parser.unexpectedToken();
     }
 
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
 
     double mean = 0.0;
     parser.getToken(mean);
@@ -109,7 +109,7 @@ void Ssta::read_dlib_line(Parser& parser) {
 
     double variance = 0.0;
     if (type == "gauss") {  // gaussian
-        parser.checkSepalator(',');
+        parser.checkSeparator(',');
 
         double sigma = 0.0;
         parser.getToken(sigma);
@@ -125,7 +125,7 @@ void Ssta::read_dlib_line(Parser& parser) {
     Normal delay(mean, variance);
     g->set_delay(in, out, delay);
 
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 }
 
@@ -154,7 +154,7 @@ void Ssta::read_bench() {
 }
 
 void Ssta::read_bench_input(Parser& parser) {
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
 
     std::string signal_name;
     parser.getToken(signal_name);
@@ -168,12 +168,12 @@ void Ssta::read_bench_input(Parser& parser) {
     in->set_name(signal_name);
     signals_[signal_name] = in;
 
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 }
 
 void Ssta::read_bench_output(Parser& parser) {
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
 
     std::string signal_name;
     parser.getToken(signal_name);
@@ -183,7 +183,7 @@ void Ssta::read_bench_output(Parser& parser) {
     }
     outputs_.insert(signal_name);
 
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 }
 
@@ -308,7 +308,7 @@ void Ssta::read_bench_net(Parser& parser, const std::string& out_signal_name) {
     NetLine l;
     l->set_out(out_signal_name);
 
-    parser.checkSepalator('=');
+    parser.checkSeparator('=');
 
     std::string gate_name;
     parser.getToken(gate_name);
@@ -330,7 +330,7 @@ void Ssta::read_bench_net(Parser& parser, const std::string& out_signal_name) {
 
     l->set_gate(gate_name);
 
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
 
     NetLineIns& ins = l->ins();
     // Reserve space for input signals (typical gates have 2-4 inputs)

--- a/test/test_coverage_gaps.cpp
+++ b/test/test_coverage_gaps.cpp
@@ -80,7 +80,7 @@ TEST_F(CoverageGapsTest, ParserUnexpectedTokenException) {
 
     // Try to check separator that doesn't match
     try {
-        parser.checkSepalator('(');  // Should fail if next token is not '('
+        parser.checkSeparator('(');  // Should fail if next token is not '('
         FAIL() << "Expected ParseException was not thrown";
     } catch (const ParseException& e) {
         std::string msg = e.what();

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -200,13 +200,13 @@ TEST_F(ParserTest, CheckSeparatorSuccess) {
     parser.checkFile();
     parser.getLine();
 
-    EXPECT_NO_THROW(parser.checkSepalator('('));
+    EXPECT_NO_THROW(parser.checkSeparator('('));
 
     std::string token;
     parser.getToken(token);
     EXPECT_EQ(token, "token");
 
-    EXPECT_NO_THROW(parser.checkSepalator(')'));
+    EXPECT_NO_THROW(parser.checkSeparator(')'));
 
     deleteTestFile("test8.txt");
 }
@@ -220,7 +220,7 @@ TEST_F(ParserTest, CheckSeparatorFailure) {
     parser.checkFile();
     parser.getLine();
 
-    EXPECT_THROW(parser.checkSepalator('['), Nh::ParseException);
+    EXPECT_THROW(parser.checkSeparator('['), Nh::ParseException);
 
     deleteTestFile("test9.txt");
 }
@@ -296,11 +296,11 @@ TEST_F(ParserTest, ParseDlibFormat) {
     parser.getToken(pin);
     parser.getToken(y);
     parser.getToken(delay_type);
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     parser.getToken(param1);
-    parser.checkSepalator(',');
+    parser.checkSeparator(',');
     parser.getToken(param2);
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 
     EXPECT_EQ(gate_name, "gate_name");
@@ -316,11 +316,11 @@ TEST_F(ParserTest, ParseDlibFormat) {
     parser.getToken(pin);
     parser.getToken(y);
     parser.getToken(delay_type);
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     parser.getToken(param1);
-    parser.checkSepalator(',');
+    parser.checkSeparator(',');
     parser.getToken(param2);
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 
     EXPECT_EQ(gate_name, "gate_name2");
@@ -347,32 +347,32 @@ TEST_F(ParserTest, ParseBenchFormat) {
     std::string keyword, signal;
     parser.getToken(keyword);
     EXPECT_EQ(keyword, "INPUT");
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     parser.getToken(signal);
     EXPECT_EQ(signal, "signal1");
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 
     // Parse OUTPUT line
     parser.getLine();
     parser.getToken(keyword);
     EXPECT_EQ(keyword, "OUTPUT");
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     parser.getToken(signal);
     EXPECT_EQ(signal, "signal2");
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 
     // Parse NET line
     parser.getLine();
     parser.getToken(keyword);  // N1
-    parser.checkSepalator('=');
+    parser.checkSeparator('=');
     parser.getToken(keyword);  // GATE
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     parser.getToken(signal);  // signal1
-    parser.checkSepalator(',');
+    parser.checkSeparator(',');
     parser.getToken(signal);  // signal3
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
     parser.checkEnd();
 
     deleteTestFile("test_bench.txt");

--- a/test/test_parser_lexical_cast.cpp
+++ b/test/test_parser_lexical_cast.cpp
@@ -178,11 +178,11 @@ TEST_F(ParserLexicalCastTest, ParseMixedTypes) {
     parser.getToken(pin);
     parser.getToken(y);
     parser.getToken(delay_type);
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     parser.getToken(param1);
-    parser.checkSepalator(',');
+    parser.checkSeparator(',');
     parser.getToken(param2);
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
 
     EXPECT_EQ(gate_name, "gate_name");
     EXPECT_EQ(pin, 0);

--- a/test/test_parser_tokenizer.cpp
+++ b/test/test_parser_tokenizer.cpp
@@ -132,12 +132,12 @@ TEST_F(ParserTokenizerTest, MixedSeparatorsDlibFormat) {
     parser.getToken(in);
     parser.getToken(out);
     parser.getToken(type);
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     double param1, param2;
     parser.getToken(param1);
-    parser.checkSepalator(',');
+    parser.checkSeparator(',');
     parser.getToken(param2);
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
 
     EXPECT_EQ(gate_name, "gate_name");
     EXPECT_EQ(in, "0");
@@ -191,9 +191,9 @@ TEST_F(ParserTokenizerTest, EmptyTokensBetweenSeparators) {
 
     std::string gate_name;
     parser.getToken(gate_name);
-    parser.checkSepalator('(');
-    parser.checkSepalator(',');
-    parser.checkSepalator(')');
+    parser.checkSeparator('(');
+    parser.checkSeparator(',');
+    parser.checkSeparator(')');
 
     EXPECT_EQ(gate_name, "gate_name");
 
@@ -249,10 +249,10 @@ TEST_F(ParserTokenizerTest, SeparatorsAtStartEnd) {
     parser.checkFile();
     parser.getLine();
 
-    parser.checkSepalator('(');
+    parser.checkSeparator('(');
     std::string token;
     parser.getToken(token);
-    parser.checkSepalator(')');
+    parser.checkSeparator(')');
 
     EXPECT_EQ(token, "token");
 


### PR DESCRIPTION
## 概要

`Parser::checkSepalator` のスペルミスを修正します。

## 変更内容

- `checkSepalator` → `checkSeparator` にリネーム
- 引数名 `sepalator` → `separator` にリネーム

## 影響範囲

| ファイル | 変更箇所 |
|----------|----------|
| `src/parser.hpp` | 宣言 |
| `src/parser.cpp` | 定義 |
| `src/ssta.cpp` | 9箇所の呼び出し |
| `test/test_parser.cpp` | 16箇所の呼び出し |
| `test/test_parser_tokenizer.cpp` | 6箇所の呼び出し |
| `test/test_parser_lexical_cast.cpp` | 3箇所の呼び出し |
| `test/test_coverage_gaps.cpp` | 1箇所の呼び出し |

## テスト結果

- ✅ ビルド成功
- ✅ 383件のユニットテスト全てパス
- ✅ 8件の統合テスト全てパス

Closes #134