### PR TITLE
refactor: define named constants for magic numbers

### DIFF
--- a/include/nhssta/ssta.hpp
+++ b/include/nhssta/ssta.hpp
@@ -24,6 +24,10 @@ class Parser;
 
 namespace Nh {
 
+// Default number of critical paths to report when -p/--path option
+// is specified without an explicit count.
+constexpr size_t DEFAULT_CRITICAL_PATH_COUNT = 5;
+
 class Ssta {
    public:
 
@@ -60,7 +64,7 @@ class Ssta {
     bool is_lat_ = false;
     bool is_correlation_ = false;
     bool is_critical_path_ = false;
-    size_t critical_path_count_ = 5;
+    size_t critical_path_count_ = DEFAULT_CRITICAL_PATH_COUNT;
     Gates gates_;
     Signals signals_;
     Net net_;
@@ -81,7 +85,7 @@ class Ssta {
     void set_correlation() {
         is_correlation_ = true;
     }
-    void set_critical_path(size_t top_n = 5) {
+    void set_critical_path(size_t top_n = DEFAULT_CRITICAL_PATH_COUNT) {
         is_critical_path_ = true;
         critical_path_count_ = top_n;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,15 +46,15 @@ void set_option(int argc, char* argv[], Nh::Ssta* ssta) {
                         i++;  // Skip the number argument
                     } catch (...) {
                         // If conversion fails, use default
-                        ssta->set_critical_path(5);
+                        ssta->set_critical_path(Nh::DEFAULT_CRITICAL_PATH_COUNT);
                     }
                 } else {
                     // No number provided, use default
-                    ssta->set_critical_path(5);
+                    ssta->set_critical_path(Nh::DEFAULT_CRITICAL_PATH_COUNT);
                 }
             } else {
                 // No more arguments, use default
-                ssta->set_critical_path(5);
+                ssta->set_critical_path(Nh::DEFAULT_CRITICAL_PATH_COUNT);
             }
         } else if (arg == "--dlib") {
             if (i + 1 < argc) {
@@ -93,15 +93,15 @@ void set_option(int argc, char* argv[], Nh::Ssta* ssta) {
                                 i++;  // Skip the number argument
                             } catch (...) {
                                 // If conversion fails, use default
-                                ssta->set_critical_path(5);
+                                ssta->set_critical_path(Nh::DEFAULT_CRITICAL_PATH_COUNT);
                             }
                         } else {
                             // No number provided, use default
-                            ssta->set_critical_path(5);
+                            ssta->set_critical_path(Nh::DEFAULT_CRITICAL_PATH_COUNT);
                         }
                     } else {
                         // No more arguments, use default
-                        ssta->set_critical_path(5);
+                        ssta->set_critical_path(Nh::DEFAULT_CRITICAL_PATH_COUNT);
                     }
                     break;
                 case 'd':

--- a/src/random_variable.cpp
+++ b/src/random_variable.cpp
@@ -113,7 +113,7 @@ double _RandomVariable_::standard_deviation() {
 
 double _RandomVariable_::coefficient_of_variation() {
     double m = mean();
-    if (std::abs(m) < 1.0e-10) {
+    if (std::abs(m) < CV_ZERO_THRESHOLD) {
         // For very small means, return a large value to indicate high relative error
         return std::numeric_limits<double>::infinity();
     }

--- a/src/random_variable.hpp
+++ b/src/random_variable.hpp
@@ -11,7 +11,14 @@
 
 namespace RandomVariable {
 
-const double MINIMUM_VARIANCE = 1.0e-6;
+// Minimum variance threshold to avoid division by zero in statistical calculations.
+// Values smaller than this are clamped to this minimum.
+constexpr double MINIMUM_VARIANCE = 1.0e-6;
+
+// Threshold for coefficient of variation calculation.
+// Mean values with absolute value smaller than this are treated as zero,
+// resulting in infinite coefficient of variation.
+constexpr double CV_ZERO_THRESHOLD = 1.0e-10;
 
 
 class _RandomVariable_;


### PR DESCRIPTION
## 概要

マジックナンバーを名前付き定数に置き換え、コードの可読性と保守性を向上させます。

## 変更内容

### 1. MINIMUM_VARIANCE (1.0e-6)
- `src/random_variable.hpp`
- ドキュメントコメントを追加
- `const` から `constexpr` に変更

### 2. CV_ZERO_THRESHOLD (1.0e-10) - 新規
- `src/random_variable.hpp` に追加
- coefficient of variation 計算時の閾値
- 平均値がこの値より小さい場合、ゼロとして扱う

### 3. DEFAULT_CRITICAL_PATH_COUNT (5) - 新規
- `include/nhssta/ssta.hpp` の `Nh` 名前空間に追加
- `Ssta` クラスと `main.cpp` CLI で使用
- ハードコードされた `5` を6箇所で置き換え

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `src/random_variable.hpp` | MINIMUM_VARIANCE にドキュメント追加、CV_ZERO_THRESHOLD 追加 |
| `src/random_variable.cpp` | CV_ZERO_THRESHOLD を使用 |
| `include/nhssta/ssta.hpp` | DEFAULT_CRITICAL_PATH_COUNT 追加、メンバ変数で使用 |
| `src/main.cpp` | Nh::DEFAULT_CRITICAL_PATH_COUNT を使用 |

## テスト結果

- ✅ ビルド成功
- ✅ 383件のユニットテスト全てパス
- ✅ 8件の統合テスト全てパス

Closes #133