### PR TITLE
refactor: remove unused error message construction

### DIFF
--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -315,15 +315,6 @@ void Ssta::read_bench_net(Parser& parser, const std::string& out_signal_name) {
     tolower_string(gate_name);
     auto gi = gates_.find(gate_name);
     if (gi == gates_.end()) {
-        std::string what = "unknown gate \"";
-        what += gate_name;
-        what += "\"";
-        what += " at line ";
-        int line = parser.getNumLine();
-        what += std::to_string(line);
-        what += " of file \"";
-        what += parser.getFileName();
-        what += "\"";
         throw Nh::ParseException(parser.getFileName(), parser.getNumLine(),
                                  "unknown gate \"" + gate_name + "\"");
     }


### PR DESCRIPTION
## 概要

`Ssta::read_bench_net()` で構築されているが使用されていない `what` 変数を削除します。

## 問題

```cpp
// 12行のコード（使用されていない）
std::string what = "unknown gate \"";
what += gate_name;
what += "\"";
what += " at line ";
int line = parser.getNumLine();
what += std::to_string(line);
what += " of file \"";
what += parser.getFileName();
what += "\"";
// ↑ この what は使われていない

throw Nh::ParseException(parser.getFileName(), parser.getNumLine(),
                         "unknown gate \"" + gate_name + "\"");
```

## 修正後

```cpp
throw Nh::ParseException(parser.getFileName(), parser.getNumLine(),
                         "unknown gate \"" + gate_name + "\"");
```

`ParseException` は内部でファイル名と行番号をフォーマットするため、手動での構築は不要です。

## 変更内容

- 9行の未使用コードを削除
- 動作に変更なし

## テスト結果

- ✅ ビルド成功
- ✅ 383件のユニットテスト全てパス
- ✅ 8件の統合テスト全てパス

Closes #135