### PR TITLE
refactor: getCriticalPaths のクリティカル入力探索ロジック重複解消 (#131)

### DIFF
--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -577,52 +577,6 @@ CriticalPaths Ssta::getCriticalPaths(size_t top_n) const {
             pin_index++;
         }
         
-        // If no critical input found with tolerance check, find input with maximum LAT + gate_delay
-        // This handles cases where MAX operation causes slight differences
-        if (critical_input.empty() && !input_signals.empty()) {
-            pin_index = 0;
-            for (const auto& input_signal : input_signals) {
-                auto input_sig_it = signals_.find(input_signal);
-                if (input_sig_it != signals_.end()) {
-                    double input_lat = input_sig_it->second->mean();
-                    std::string pin_name = std::to_string(pin_index);
-                    
-                    auto delay_it2 = delays_map.find(pin_name);
-                    if (delay_it2 != delays_map.end()) {
-                        const Normal& gate_delay = delay_it2->second;
-                        double contribution = input_lat + gate_delay->mean();
-                        if (contribution > max_contribution) {
-                            max_contribution = contribution;
-                            critical_input = input_signal;
-                        }
-                    } else {
-                        // Delay not found, just use LAT
-                        if (input_lat > max_contribution) {
-                            max_contribution = input_lat;
-                            critical_input = input_signal;
-                        }
-                    }
-                }
-                pin_index++;
-            }
-        }
-        
-        // If still no critical input found, use the input with maximum LAT
-        // This is a fallback for edge cases
-        if (critical_input.empty() && !input_signals.empty()) {
-            double max_lat = std::numeric_limits<double>::lowest();
-            for (const auto& input_signal : input_signals) {
-                auto input_sig_it = signals_.find(input_signal);
-                if (input_sig_it != signals_.end()) {
-                    double input_lat = input_sig_it->second->mean();
-                    if (input_lat > max_lat) {
-                        max_lat = input_lat;
-                        critical_input = input_signal;
-                    }
-                }
-            }
-        }
-        
         // Add instance to path
         instance_path.push_back(instance_name);
         


### PR DESCRIPTION
## 概要

Issue #131 の対応として、`getCriticalPaths()` メソッド内のクリティカル入力探索ロジックの重複を解消しました。

## 問題点

`src/ssta.cpp` の `getCriticalPaths()` メソッドで、同じロジックが3回繰り返されていました：

| ループ | 行番号 | 内容 |
|--------|--------|------|
| Loop 1 | 544-578 | メインロジック（LAT + gate_delay の最大値追跡） |
| Loop 2 | 582-608 | **冗長** - Loop 1 と同じロジック |
| Loop 3 | 612-624 | **冗長** - LAT のみのフォールバック |

## 分析結果

Loop 1 は既に両方のケースを処理していました：
```cpp
// gate_delay が見つかった場合
if (delay_it != delays_map.end()) {
    const Normal& gate_delay = delay_it->second;
    double contribution = input_lat + gate_delay->mean();
    if (contribution > max_contribution) {
        max_contribution = contribution;
        critical_input = input_signal;
    }
} else {
    // gate_delay が見つからない場合は LAT のみ使用
    if (input_lat > max_contribution) {
        max_contribution = input_lat;
        critical_input = input_signal;
    }
}
```

Loop 2 と Loop 3 は `critical_input.empty()` の場合にのみ実行されますが、Loop 1 が入力信号を見つけた場合は必ず `critical_input` が設定されるため、これらは到達不能コードでした。

## 変更内容

**削除:** ~45行の冗長コード（Loop 2 と Loop 3）

既存のフォールバック（lines 631-639）はそのまま維持し、入力信号が見つからない場合の処理を継続しています。

## テスト結果

```
[==========] Running 430 tests from 44 test suites.
[  PASSED  ] 430 tests.

CriticalPathTest: 23 tests passed
✓ All integration tests passed!
```

## 関連 Issue

Closes #131