### PR TITLE
refactor: RandomVariable の const 正確性改善 (#132)

### DIFF
--- a/src/random_variable.cpp
+++ b/src/random_variable.cpp
@@ -77,7 +77,7 @@ const RandomVariable& RandomVariableImpl::right() const {
     return right_;
 }
 
-double RandomVariableImpl::mean() {
+double RandomVariableImpl::mean() const {
     if (!is_set_mean_) {
         mean_ = calc_mean();
         is_set_mean_ = true;
@@ -86,7 +86,7 @@ double RandomVariableImpl::mean() {
     return mean_;
 }
 
-double RandomVariableImpl::variance() {
+double RandomVariableImpl::variance() const {
     if (!is_set_variance_) {
         variance_ = calc_variance();
         if (std::isnan(variance_)) {
@@ -106,12 +106,12 @@ double RandomVariableImpl::calc_variance() const {
     return variance_;
 }
 
-double RandomVariableImpl::standard_deviation() {
+double RandomVariableImpl::standard_deviation() const {
     double v = variance();
     return std::sqrt(v);
 }
 
-double RandomVariableImpl::coefficient_of_variation() {
+double RandomVariableImpl::coefficient_of_variation() const {
     double m = mean();
     if (std::abs(m) < CV_ZERO_THRESHOLD) {
         // For very small means, return a large value to indicate high relative error
@@ -121,7 +121,7 @@ double RandomVariableImpl::coefficient_of_variation() {
     return sd / std::abs(m);
 }
 
-double RandomVariableImpl::relative_error() {
+double RandomVariableImpl::relative_error() const {
     return coefficient_of_variation();
 }
 

--- a/src/random_variable.hpp
+++ b/src/random_variable.hpp
@@ -121,13 +121,13 @@ class RandomVariableImpl {
     [[nodiscard]] const RandomVariable& left() const;
     [[nodiscard]] const RandomVariable& right() const;
 
-    double mean();
-    double variance();
+    [[nodiscard]] double mean() const;
+    [[nodiscard]] double variance() const;
 
     // Numerical error metrics
-    [[nodiscard]] double standard_deviation();
-    [[nodiscard]] double coefficient_of_variation();
-    [[nodiscard]] double relative_error();  // Alias for coefficient_of_variation
+    [[nodiscard]] double standard_deviation() const;
+    [[nodiscard]] double coefficient_of_variation() const;
+    [[nodiscard]] double relative_error() const;  // Alias for coefficient_of_variation
 
     [[nodiscard]] int level() const {
         return level_;
@@ -150,11 +150,14 @@ class RandomVariableImpl {
     // left_ and right_ share ownership with any external Handles that reference them
     RandomVariable left_;
     RandomVariable right_;
-    double mean_;
-    double variance_;
-
-    bool is_set_mean_;
-    bool is_set_variance_;
+    
+    // Cache variables are mutable to allow lazy evaluation in const methods
+    // These represent cached computed values, not observable state
+    mutable double mean_;
+    mutable double variance_;
+    mutable bool is_set_mean_;
+    mutable bool is_set_variance_;
+    
     int level_;
 };
 

--- a/test/test_randomvariable.cpp
+++ b/test/test_randomvariable.cpp
@@ -88,3 +88,43 @@ TEST_F(RandomVariableTest, OperationResultSurvivesSourceScope) {
     EXPECT_DOUBLE_EQ(sum->mean(), 7.0);
     EXPECT_DOUBLE_EQ(sum->variance(), 0.5);
 }
+
+// Test const correctness: mean() and variance() should be callable on const RandomVariableImpl&
+// This tests the actual const-correctness of the implementation class methods
+TEST_F(RandomVariableTest, ConstCorrectnessImplMeanVariance) {
+    RandomVariable::Normal n(10.0, 4.0);
+    
+    // Get a const reference to the underlying implementation
+    const RandomVariable::RandomVariableImpl& const_impl = *n.get();
+    
+    // These should compile and work correctly on const reference to implementation
+    EXPECT_DOUBLE_EQ(const_impl.mean(), 10.0);
+    EXPECT_DOUBLE_EQ(const_impl.variance(), 4.0);
+}
+
+// Test that const reference works with computed values (lazy evaluation)
+TEST_F(RandomVariableTest, ConstCorrectnessWithLazyEvaluation) {
+    RandomVariable::Normal a(3.0, 1.0);
+    RandomVariable::Normal b(4.0, 1.0);
+    RandomVar sum = a + b;
+    
+    // Get a const reference to the underlying implementation
+    const RandomVariable::RandomVariableImpl& const_impl = *sum.get();
+    
+    // mean() and variance() should work on const reference even with lazy evaluation
+    EXPECT_DOUBLE_EQ(const_impl.mean(), 7.0);
+    EXPECT_DOUBLE_EQ(const_impl.variance(), 2.0);
+}
+
+// Test that standard_deviation and coefficient_of_variation are also const-correct
+TEST_F(RandomVariableTest, ConstCorrectnessStatMethods) {
+    RandomVariable::Normal n(10.0, 4.0);
+    
+    // Get a const reference to the underlying implementation
+    const RandomVariable::RandomVariableImpl& const_impl = *n.get();
+    
+    // These derived methods should also work on const references
+    EXPECT_DOUBLE_EQ(const_impl.standard_deviation(), 2.0);
+    EXPECT_NEAR(const_impl.coefficient_of_variation(), 0.2, 1e-10);
+    EXPECT_NEAR(const_impl.relative_error(), 0.2, 1e-10);
+}


### PR DESCRIPTION
## 概要

Issue #132 の対応として、`RandomVariable` の `mean()` と `variance()` メソッドの const 正確性を改善しました。

## 問題点

`mean()` と `variance()` は内部キャッシュを更新するため non-const でしたが、論理的には const であるべきでした：

```cpp
// Before: const RandomVariableImpl& から呼び出せない
double mean();
double variance();
```

## 変更内容

### 1. キャッシュ変数を mutable に

```cpp
// キャッシュ変数は観測可能な状態ではないため mutable
mutable double mean_;
mutable double variance_;
mutable bool is_set_mean_;
mutable bool is_set_variance_;
```

### 2. メソッドを const に変更

| メソッド | Before | After |
|----------|--------|-------|
| `mean()` | `double mean();` | `[[nodiscard]] double mean() const;` |
| `variance()` | `double variance();` | `[[nodiscard]] double variance() const;` |
| `standard_deviation()` | `double standard_deviation();` | `[[nodiscard]] double standard_deviation() const;` |
| `coefficient_of_variation()` | `double coefficient_of_variation();` | `[[nodiscard]] double coefficient_of_variation() const;` |
| `relative_error()` | `double relative_error();` | `[[nodiscard]] double relative_error() const;` |

### 3. テスト追加（3件）

| テスト | 内容 |
|--------|------|
| `ConstCorrectnessImplMeanVariance` | `const RandomVariableImpl&` で `mean()/variance()` 呼び出し |
| `ConstCorrectnessWithLazyEvaluation` | 遅延評価が const 参照で動作 |
| `ConstCorrectnessStatMethods` | 派生メソッドも const 参照で動作 |

## テスト結果

```
[==========] Running 430 tests from 44 test suites.
[  PASSED  ] 430 tests.
✓ All integration tests passed!
```

## 関連 Issue

Closes #132