### PR TITLE
refactor: Handle suffix 命名規則の統一

### DIFF
--- a/include/nhssta/gate.hpp
+++ b/include/nhssta/gate.hpp
@@ -22,7 +22,7 @@ typedef ::RandomVariable::Normal Normal;
 typedef ::RandomVariable::RandomVariable RandomVariable;
 
 class InstanceImpl;
-class Instance;
+class InstanceHandle;
 // Use unordered_map for better performance (O(1) average vs O(log n) for map)
 typedef std::unordered_map<std::string, RandomVariable> Signals;
 
@@ -87,10 +87,10 @@ class GateImpl {
 // - Passing by value (Gate) transfers/shares ownership
 // - Passing by const reference (const Gate&) is a non-owning reference
 // - Storing as member variable creates ownership relationship
-class Gate {
+class GateHandle {
    public:
-    Gate();
-    explicit Gate(std::shared_ptr<GateImpl> body);
+    GateHandle();
+    explicit GateHandle(std::shared_ptr<GateImpl> body);
 
     // Non-owning access: returns raw pointer (no ownership transfer)
     GateImpl* operator->() const {
@@ -105,13 +105,16 @@ class Gate {
         return body_;
     }
 
-    [[nodiscard]] Instance create_instance() const;
+    [[nodiscard]] InstanceHandle create_instance() const;
 
    private:
-    // Owned shared_ptr: this Gate owns the underlying object
-    // Copying the Gate shares this ownership (lightweight copy)
+    // Owned shared_ptr: this GateHandle owns the underlying object
+    // Copying the GateHandle shares this ownership (lightweight copy)
     std::shared_ptr<GateImpl> body_;
 };
+
+// Type alias: Gate is a Handle (thin wrapper around std::shared_ptr)
+using Gate = GateHandle;
 
 /////
 
@@ -144,10 +147,10 @@ class InstanceImpl {
 // - Copying an Instance is lightweight: it shares ownership via std::shared_ptr
 // - Passing by value (Instance) transfers/shares ownership
 // - Passing by const reference (const Instance&) is a non-owning reference
-class Instance {
+class InstanceHandle {
    public:
-    Instance() = default;
-    explicit Instance(std::shared_ptr<InstanceImpl> body)
+    InstanceHandle() = default;
+    explicit InstanceHandle(std::shared_ptr<InstanceImpl> body)
         : body_(std::move(body)) {}
 
     // Non-owning access: returns raw pointer (no ownership transfer)
@@ -163,18 +166,21 @@ class Instance {
         return body_;
     }
 
-    bool operator==(const Instance& rhs) const {
+    bool operator==(const InstanceHandle& rhs) const {
         return body_.get() == rhs.body_.get();
     }
-    bool operator!=(const Instance& rhs) const {
+    bool operator!=(const InstanceHandle& rhs) const {
         return !(*this == rhs);
     }
 
    private:
-    // Owned shared_ptr: this Instance owns the underlying object
-    // Copying the Instance shares this ownership (lightweight copy)
+    // Owned shared_ptr: this InstanceHandle owns the underlying object
+    // Copying the InstanceHandle shares this ownership (lightweight copy)
     std::shared_ptr<InstanceImpl> body_;
 };
+
+// Type alias: Instance is a Handle (thin wrapper around std::shared_ptr)
+using Instance = InstanceHandle;
 }  // namespace Nh
 
 #endif  // NH_GATE__H

--- a/src/covariance.hpp
+++ b/src/covariance.hpp
@@ -45,11 +45,11 @@ class CovarianceMatrixImpl {
     Matrix cmat;
 };
 
-class CovarianceMatrix {
+class CovarianceMatrixHandle {
    public:
-    CovarianceMatrix()
+    CovarianceMatrixHandle()
         : body_(std::make_shared<CovarianceMatrixImpl>()) {}
-    explicit CovarianceMatrix(std::shared_ptr<CovarianceMatrixImpl> body)
+    explicit CovarianceMatrixHandle(std::shared_ptr<CovarianceMatrixImpl> body)
         : body_(std::move(body)) {}
 
     CovarianceMatrixImpl* operator->() const {
@@ -65,6 +65,9 @@ class CovarianceMatrix {
    private:
     std::shared_ptr<CovarianceMatrixImpl> body_;
 };
+
+// Type alias: CovarianceMatrix is a Handle (thin wrapper around std::shared_ptr)
+using CovarianceMatrix = CovarianceMatrixHandle;
 
 double covariance(const Normal& a, const Normal& b);
 double covariance(const RandomVariable& a, const RandomVariable& b);

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -15,19 +15,19 @@
 
 namespace Nh {
 
-Gate::Gate()
+GateHandle::GateHandle()
     : body_(std::make_shared<GateImpl>()) {}
 
-Gate::Gate(std::shared_ptr<GateImpl> body)
+GateHandle::GateHandle(std::shared_ptr<GateImpl> body)
     : body_(std::move(body)) {
     if (!body_) {
         throw Nh::RuntimeException("Gate: null body");
     }
 }
 
-Instance Gate::create_instance() const {
+InstanceHandle GateHandle::create_instance() const {
     auto inst_body = std::make_shared<InstanceImpl>(*this);
-    Instance inst(inst_body);
+    InstanceHandle inst(inst_body);
     inst->set_name((*this)->allocate_instance_name());
     return inst;
 }

--- a/src/gate.hpp
+++ b/src/gate.hpp
@@ -18,7 +18,7 @@ using Normal = ::RandomVariable::Normal;
 using RandomVariable = ::RandomVariable::RandomVariable;
 
 class InstanceImpl;
-class Instance;
+class InstanceHandle;
 // Use unordered_map for better performance (O(1) average vs O(log n) for map)
 using Signals = std::unordered_map<std::string, RandomVariable>;
 
@@ -83,10 +83,10 @@ class GateImpl {
 // - Passing by value (Gate) transfers/shares ownership
 // - Passing by const reference (const Gate&) is a non-owning reference
 // - Storing as member variable creates ownership relationship
-class Gate {
+class GateHandle {
    public:
-    Gate();
-    explicit Gate(std::shared_ptr<GateImpl> body);
+    GateHandle();
+    explicit GateHandle(std::shared_ptr<GateImpl> body);
 
     // Non-owning access: returns raw pointer (no ownership transfer)
     GateImpl* operator->() const {
@@ -101,13 +101,16 @@ class Gate {
         return body_;
     }
 
-    [[nodiscard]] Instance create_instance() const;
+    [[nodiscard]] InstanceHandle create_instance() const;
 
    private:
-    // Owned shared_ptr: this Gate owns the underlying object
-    // Copying the Gate shares this ownership (lightweight copy)
+    // Owned shared_ptr: this GateHandle owns the underlying object
+    // Copying the GateHandle shares this ownership (lightweight copy)
     std::shared_ptr<GateImpl> body_;
 };
+
+// Type alias: Gate is a Handle (thin wrapper around std::shared_ptr)
+using Gate = GateHandle;
 
 /////
 
@@ -140,10 +143,10 @@ class InstanceImpl {
 // - Copying an Instance is lightweight: it shares ownership via std::shared_ptr
 // - Passing by value (Instance) transfers/shares ownership
 // - Passing by const reference (const Instance&) is a non-owning reference
-class Instance {
+class InstanceHandle {
    public:
-    Instance() = default;
-    explicit Instance(std::shared_ptr<InstanceImpl> body)
+    InstanceHandle() = default;
+    explicit InstanceHandle(std::shared_ptr<InstanceImpl> body)
         : body_(std::move(body)) {}
 
     // Non-owning access: returns raw pointer (no ownership transfer)
@@ -159,18 +162,21 @@ class Instance {
         return body_;
     }
 
-    bool operator==(const Instance& rhs) const {
+    bool operator==(const InstanceHandle& rhs) const {
         return body_.get() == rhs.body_.get();
     }
-    bool operator!=(const Instance& rhs) const {
+    bool operator!=(const InstanceHandle& rhs) const {
         return !(*this == rhs);
     }
 
    private:
-    // Owned shared_ptr: this Instance owns the underlying object
-    // Copying the Instance shares this ownership (lightweight copy)
+    // Owned shared_ptr: this InstanceHandle owns the underlying object
+    // Copying the InstanceHandle shares this ownership (lightweight copy)
     std::shared_ptr<InstanceImpl> body_;
 };
+
+// Type alias: Instance is a Handle (thin wrapper around std::shared_ptr)
+using Instance = InstanceHandle;
 }  // namespace Nh
 
 #endif  // NH_GATE__H

--- a/test/test_namespace_consistency.cpp
+++ b/test/test_namespace_consistency.cpp
@@ -135,3 +135,41 @@ TEST_F(NamespaceConsistencyTest, ImplNamingConvention) {
 
     EXPECT_TRUE(true);
 }
+
+// Test: Handle classes use 'Handle' suffix with using alias for public API
+// This ensures consistent naming pattern across all handle types
+TEST_F(NamespaceConsistencyTest, HandleSuffixNamingConvention) {
+    // RandomVariableHandle is aliased as RandomVariable
+    static_assert(std::is_class<RandomVariable::RandomVariableHandle>::value,
+                  "RandomVariableHandle should exist");
+    static_assert(std::is_same<RandomVariable::RandomVariable,
+                               RandomVariable::RandomVariableHandle>::value,
+                  "RandomVariable should be alias of RandomVariableHandle");
+
+    // ExpressionHandle is aliased as Expression
+    static_assert(std::is_class<ExpressionHandle>::value,
+                  "ExpressionHandle should exist");
+    static_assert(std::is_same<Expression, ExpressionHandle>::value,
+                  "Expression should be alias of ExpressionHandle");
+
+    // GateHandle is aliased as Gate
+    static_assert(std::is_class<Nh::GateHandle>::value,
+                  "GateHandle should exist in Nh namespace");
+    static_assert(std::is_same<Nh::Gate, Nh::GateHandle>::value,
+                  "Gate should be alias of GateHandle");
+
+    // InstanceHandle is aliased as Instance
+    static_assert(std::is_class<Nh::InstanceHandle>::value,
+                  "InstanceHandle should exist in Nh namespace");
+    static_assert(std::is_same<Nh::Instance, Nh::InstanceHandle>::value,
+                  "Instance should be alias of InstanceHandle");
+
+    // CovarianceMatrixHandle is aliased as CovarianceMatrix
+    static_assert(std::is_class<RandomVariable::CovarianceMatrixHandle>::value,
+                  "CovarianceMatrixHandle should exist");
+    static_assert(std::is_same<RandomVariable::CovarianceMatrix,
+                               RandomVariable::CovarianceMatrixHandle>::value,
+                  "CovarianceMatrix should be alias of CovarianceMatrixHandle");
+
+    EXPECT_TRUE(true);
+}


### PR DESCRIPTION
## 概要

Handle パターンを使用するクラスの命名規則を統一しました。

## 問題点

Handle クラスの命名が混在していました：

| クラス | 旧命名 | パターン |
|--------|--------|----------|
| `RandomVariableHandle` | ✅ Handle suffix | using alias |
| `ExpressionHandle` | ✅ Handle suffix | using alias |
| `Gate` | ❌ なし | 直接命名 |
| `Instance` | ❌ なし | 直接命名 |
| `CovarianceMatrix` | ❌ なし | 直接命名 |

## 変更内容

すべてのハンドルクラスを `*Handle` suffix + `using` alias パターンに統一：

| 内部クラス名 | 公開 API 名 |
|--------------|-------------|
| `GateHandle` | `Gate` |
| `InstanceHandle` | `Instance` |
| `CovarianceMatrixHandle` | `CovarianceMatrix` |

### コード例

```cpp
// 内部クラス（明示的にHandleであることを示す）
class GateHandle {
    std::shared_ptr<GateImpl> body_;
    // ...
};

// 公開API（シンプルな名前）
using Gate = GateHandle;
```

## メリット

1. **内部実装の明確さ** - 開発者がコードを読む際「これはハンドルパターン」と即座に判断可能
2. **API の簡潔さ** - 公開 API 利用者は従来通りシンプルな名前を使用
3. **一貫性** - `RandomVariable` / `Expression` と同じパターン

## テスト追加

`HandleSuffixNamingConvention` テストを追加し、すべての Handle クラスが正しい命名規則に従っていることを検証

## テスト結果

```
[==========] Running 434 tests from 44 test suites.
[  PASSED  ] 434 tests.
✓ All integration tests passed!
```