### PR TITLE
refactor: net_line.hpp の命名規則適用

### DIFF
--- a/include/nhssta/ssta.hpp
+++ b/include/nhssta/ssta.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-// smart_ptr.hpp no longer needed - NetLineBody uses std::shared_ptr directly
+// smart_ptr.hpp no longer needed - NetLineImpl uses std::shared_ptr directly
 #include <nhssta/exception.hpp>
 #include <nhssta/ssta_results.hpp>
 

--- a/test/test_namespace_consistency.cpp
+++ b/test/test_namespace_consistency.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <nhssta/exception.hpp>
+#include <nhssta/net_line.hpp>
 #include <nhssta/ssta.hpp>
 
 #include "../src/covariance.hpp"
@@ -170,6 +171,16 @@ TEST_F(NamespaceConsistencyTest, HandleSuffixNamingConvention) {
     static_assert(std::is_same<RandomVariable::CovarianceMatrix,
                                RandomVariable::CovarianceMatrixHandle>::value,
                   "CovarianceMatrix should be alias of CovarianceMatrixHandle");
+
+    // NetLineHandle is aliased as NetLine
+    static_assert(std::is_class<Nh::NetLineHandle>::value,
+                  "NetLineHandle should exist in Nh namespace");
+    static_assert(std::is_same<Nh::NetLine, Nh::NetLineHandle>::value,
+                  "NetLine should be alias of NetLineHandle");
+
+    // NetLineImpl should exist (implementation class)
+    static_assert(std::is_class<Nh::NetLineImpl>::value,
+                  "NetLineImpl should exist in Nh namespace");
 
     EXPECT_TRUE(true);
 }


### PR DESCRIPTION
## 概要

`net_line.hpp` を確立された命名規則に従うよう修正しました。

## 変更内容

| Before | After | 説明 |
|--------|-------|------|
| `NetLineBody` | `NetLineImpl` | Impl suffix (実装クラス) |
| `NetLine` class | `NetLineHandle` | Handle suffix (ハンドルクラス) |
| - | `using NetLine = NetLineHandle;` | 公開 API 用 alias |
| `typedef std::vector<...> NetLineIns` | `using NetLineIns = std::vector<...>` | modern C++ syntax |

## 統一後の Handle パターン一覧（全6クラス）

| 内部クラス名 | 公開 API 名 |
|--------------|-------------|
| `RandomVariableHandle` | `RandomVariable` |
| `ExpressionHandle` | `Expression` |
| `GateHandle` | `Gate` |
| `InstanceHandle` | `Instance` |
| `CovarianceMatrixHandle` | `CovarianceMatrix` |
| `NetLineHandle` | `NetLine` ✨ NEW |

## テスト

- `HandleSuffixNamingConvention` テストに `NetLineHandle` と `NetLineImpl` の検証を追加

## テスト結果

```
[==========] Running 434 tests from 44 test suites.
[  PASSED  ] 434 tests.
✓ All integration tests passed!
```