### PR TITLE
fix: expected_prod_pos_expr に欠落していた (1-ρ²) 係数を追加

### DIFF
--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -661,7 +661,7 @@ Expression expected_prod_pos_expr(const Expression& mu0, const Expression& sigma
     // E[D0⁺ D1⁺] = μ0 μ1 Φ₂(a0, a1; ρ)
     //            + μ0 σ1 φ(a1) Φ((a0 - ρa1)/√(1-ρ²))
     //            + μ1 σ0 φ(a0) Φ((a1 - ρa0)/√(1-ρ²))
-    //            + σ0 σ1 [ρ Φ₂(a0, a1; ρ) + φ₂(a0, a1; ρ)]
+    //            + σ0 σ1 [ρ Φ₂(a0, a1; ρ) + (1-ρ²) φ₂(a0, a1; ρ)]
     //
     // where a0 = μ0/σ0, a1 = μ1/σ1
 
@@ -689,7 +689,7 @@ Expression expected_prod_pos_expr(const Expression& mu0, const Expression& sigma
     Expression term1 = mu0 * mu1 * Phi2_a0_a1;
     Expression term2 = mu0 * sigma1 * phi_a1 * Phi_cond_0;
     Expression term3 = mu1 * sigma0 * phi_a0 * Phi_cond_1;
-    Expression term4 = sigma0 * sigma1 * (rho * Phi2_a0_a1 + phi2_a0_a1);
+    Expression term4 = sigma0 * sigma1 * (rho * Phi2_a0_a1 + one_minus_rho2 * phi2_a0_a1);
 
     return term1 + term2 + term3 + term4;
 }

--- a/test/test_cov_max0_max0_expr.cpp
+++ b/test/test_cov_max0_max0_expr.cpp
@@ -426,6 +426,41 @@ TEST_F(CovMax0Max0ExprTest, ExpectedProdPos_GradientRho) {
     EXPECT_NEAR(rho->gradient(), expected_grad, 1e-3);
 }
 
+TEST_F(CovMax0Max0ExprTest, ExpectedProdPos_HighCorrelation) {
+    // Issue #189: Test with high ρ to detect missing (1-ρ²) coefficient
+    // ρ = 0.9 → (1-ρ²) = 0.19
+    // φ₂ term coefficient bug becomes significant
+    Variable mu0, sigma0, mu1, sigma1, rho;
+    mu0 = 1.0;   // Small μ/σ to make φ₂ contribution significant
+    sigma0 = 1.0;
+    mu1 = 1.0;
+    sigma1 = 1.0;
+    rho = 0.9;
+
+    Expression result = expected_prod_pos_expr(mu0, sigma0, mu1, sigma1, rho);
+    double rv_result = RandomVariable::expected_prod_pos(1.0, 1.0, 1.0, 1.0, 0.9);
+
+    // Should match numerical result within 1%
+    EXPECT_NEAR(result->value(), rv_result, rv_result * 0.01);
+}
+
+TEST_F(CovMax0Max0ExprTest, ExpectedProdPos_VeryHighCorrelation) {
+    // Issue #189: Test with very high ρ
+    // ρ = 0.95 → (1-ρ²) = 0.0975
+    Variable mu0, sigma0, mu1, sigma1, rho;
+    mu0 = 0.5;
+    sigma0 = 1.0;
+    mu1 = 0.5;
+    sigma1 = 1.0;
+    rho = 0.95;
+
+    Expression result = expected_prod_pos_expr(mu0, sigma0, mu1, sigma1, rho);
+    double rv_result = RandomVariable::expected_prod_pos(0.5, 1.0, 0.5, 1.0, 0.95);
+
+    // Should match numerical result within 1%
+    EXPECT_NEAR(result->value(), rv_result, rv_result * 0.01);
+}
+
 // ============================================================================
 // 5-6: cov_max0_max0_expr Tests
 // ============================================================================


### PR DESCRIPTION
## 概要

Issue #189 の修正。`expected_prod_pos_expr` 関数の φ₂ 項に欠落していた `(1-ρ²)` 係数を追加。

## 変更内容

### src/expression.cpp

**修正前:**
```cpp
//            + σ0 σ1 [ρ Φ₂(a0, a1; ρ) + φ₂(a0, a1; ρ)]
Expression term4 = sigma0 * sigma1 * (rho * Phi2_a0_a1 + phi2_a0_a1);
```

**修正後:**
```cpp
//            + σ0 σ1 [ρ Φ₂(a0, a1; ρ) + (1-ρ²) φ₂(a0, a1; ρ)]
Expression term4 = sigma0 * sigma1 * (rho * Phi2_a0_a1 + one_minus_rho2 * phi2_a0_a1);
```

### test/test_cov_max0_max0_expr.cpp

高い相関係数でのテストケースを追加:
- `ExpectedProdPos_HighCorrelation` (ρ = 0.9)
- `ExpectedProdPos_VeryHighCorrelation` (ρ = 0.95)

## 検証結果

| ρ | 修正前誤差 | 修正後誤差 |
|---|----------|----------|
| 0.9 | 9.4% | < 1% |
| 0.95 | 40% | < 1% |

## テスト

```
[  PASSED  ] 622 tests.
```

Closes #189