### PR TITLE
fix: EXPECT_THROW での [[nodiscard]] 警告を修正

### DIFF
--- a/test/test_custom_function.cpp
+++ b/test/test_custom_function.cpp
@@ -522,8 +522,8 @@ TEST_F(CustomFunctionTest, InvalidInputSize) {
     );
 
     // Should throw when calling with wrong input size
-    EXPECT_THROW(f.value({1.0}), Nh::RuntimeException);
-    EXPECT_THROW(f.gradient({1.0, 2.0, 3.0}), Nh::RuntimeException);
+    EXPECT_THROW((void)f.value({1.0}), Nh::RuntimeException);
+    EXPECT_THROW((void)f.gradient({1.0, 2.0, 3.0}), Nh::RuntimeException);
 }
 
 // Test: Default name generation
@@ -667,10 +667,10 @@ TEST_F(CustomFunctionTest, InvalidCustomFunction) {
     EXPECT_FALSE(static_cast<bool>(f));
 
     // Should throw when accessing methods
-    EXPECT_THROW(f.input_dim(), Nh::RuntimeException);
-    EXPECT_THROW(f.name(), Nh::RuntimeException);
-    EXPECT_THROW(f.value({1.0}), Nh::RuntimeException);
-    EXPECT_THROW(f.gradient({1.0}), Nh::RuntimeException);
+    EXPECT_THROW((void)f.input_dim(), Nh::RuntimeException);
+    EXPECT_THROW((void)f.name(), Nh::RuntimeException);
+    EXPECT_THROW((void)f.value({1.0}), Nh::RuntimeException);
+    EXPECT_THROW((void)f.gradient({1.0}), Nh::RuntimeException);
 }
 
 // Test: Custom function with division (potential division by zero)
@@ -691,7 +691,7 @@ TEST_F(CustomFunctionTest, DivisionInCustomFunction) {
     EXPECT_DOUBLE_EQ(grad[1], -1.5);  // df/dy = -x/y² = -6/4 = -1.5
 
     // Division by zero should throw
-    EXPECT_THROW(f.value({1.0, 0.0}), Nh::RuntimeException);
+    EXPECT_THROW((void)f.value({1.0, 0.0}), Nh::RuntimeException);
 }
 
 // Test: Custom function with logarithm (potential log of negative)
@@ -711,7 +711,7 @@ TEST_F(CustomFunctionTest, LogarithmInCustomFunction) {
     EXPECT_NEAR(grad[0], 1.0 / std::exp(1.0), 1e-10);
 
     // Log of negative should throw
-    EXPECT_THROW(f.value({-1.0}), Nh::RuntimeException);
+    EXPECT_THROW((void)f.value({-1.0}), Nh::RuntimeException);
 }
 
 // Test: Custom function reuse (same function, different inputs)


### PR DESCRIPTION
## 概要

`EXPECT_THROW` マクロ内で `[[nodiscard]]` 属性を持つ関数の戻り値を無視している警告を修正しました。

## 変更内容

`EXPECT_THROW` マクロ内で呼び出される `[[nodiscard]]` 属性を持つ関数の戻り値を、`(void)` キャストで明示的に無視するように変更しました。

## 修正箇所

- `f.value()` の呼び出し (4箇所)
- `f.gradient()` の呼び出し (2箇所)
- `f.input_dim()` の呼び出し (1箇所)
- `f.name()` の呼び出し (1箇所)

## テスト結果

すべてのテストがパス（708件）

## 関連

PR #194 のマージ後に発見された警告の修正