### PR TITLE
refactor: Add Phi2_expr function for consistent interface

### DIFF
--- a/src/statistical_functions.cpp
+++ b/src/statistical_functions.cpp
@@ -134,6 +134,22 @@ Expression max0_var_expr(const Expression& mu, const Expression& sigma) {
 // Bivariate normal distribution functions
 // =============================================================================
 
+// Phi2_expr: Φ₂(h, k; ρ) = Bivariate normal CDF
+// 
+// Note: bivariate_normal_cdf uses numerical integration (Simpson's rule),
+// which cannot be directly expressed as an Expression tree. Therefore,
+// we create a PHI2 node directly, which handles both value computation
+// (via bivariate_normal_cdf) and gradient computation internally.
+//
+// This function provides a consistent interface for creating PHI2 nodes,
+// similar to other statistical functions, even though the underlying
+// implementation still uses the PHI2 operation.
+Expression Phi2_expr(const Expression& h, const Expression& k, const Expression& rho) {
+    // Φ₂(h, k; ρ) = Bivariate normal CDF
+    // Create PHI2 node directly - it handles numerical integration internally
+    return Expression(std::make_shared<ExpressionImpl>(ExpressionImpl::PHI2, h, k, rho));
+}
+
 // expected_prod_pos_expr implemented as a custom function
 static CustomFunction expected_prod_pos_func = CustomFunction::create(
     5,
@@ -157,8 +173,8 @@ static CustomFunction expected_prod_pos_func = CustomFunction::create(
         Expression one_minus_rho2 = Const(1.0) - rho * rho;
         Expression sqrt_one_minus_rho2 = sqrt(one_minus_rho2);
 
-        // Φ₂(a0, a1; ρ) - create PHI2 node directly to avoid dependency on Phi2_expr
-        Expression Phi2_a0_a1 = Expression(std::make_shared<ExpressionImpl>(ExpressionImpl::PHI2, a0, a1, rho));
+        // Φ₂(a0, a1; ρ) - use Phi2_expr for consistency
+        Expression Phi2_a0_a1 = Phi2_expr(a0, a1, rho);
 
         // φ(a0) and φ(a1)
         Expression phi_a0 = phi_expr(a0);

--- a/src/statistical_functions.hpp
+++ b/src/statistical_functions.hpp
@@ -129,6 +129,47 @@ Expression max0_var_expr(const Expression& mu, const Expression& sigma);
  * 
  * @note Implemented as a custom function for code clarity and consistency
  */
+/**
+ * @brief Bivariate normal CDF: Φ₂(h, k; ρ)
+ * 
+ * Computes the cumulative distribution function of a bivariate normal
+ * distribution using numerical integration (Simpson's rule).
+ * 
+ * Gradient formulas:
+ *   ∂Φ₂/∂h = φ(h) × Φ((k - ρh)/√(1-ρ²))
+ *   ∂Φ₂/∂k = φ(k) × Φ((h - ρk)/√(1-ρ²))
+ *   ∂Φ₂/∂ρ = φ₂(h, k; ρ) (bivariate normal PDF)
+ * 
+ * @param h First argument
+ * @param k Second argument
+ * @param rho Correlation coefficient
+ * @return Expression representing Φ₂(h, k; ρ)
+ * 
+ * @note Uses PHI2 operation internally for numerical integration.
+ *       This function provides a consistent interface similar to other
+ *       statistical functions.
+ */
+Expression Phi2_expr(const Expression& h, const Expression& k, const Expression& rho);
+
+/**
+ * @brief E[D0⁺ D1⁺] for bivariate normal distribution
+ *
+ * E[D0⁺ D1⁺] = μ0 μ1 Φ₂(a0, a1; ρ)
+ *            + μ0 σ1 φ(a1) Φ((a0 - ρa1)/√(1-ρ²))
+ *            + μ1 σ0 φ(a0) Φ((a1 - ρa0)/√(1-ρ²))
+ *            + σ0 σ1 [ρ Φ₂(a0, a1; ρ) + (1-ρ²) φ₂(a0, a1; ρ)]
+ * 
+ * where a0 = μ0/σ0, a1 = μ1/σ1
+ * 
+ * @param mu0 Mean of D0
+ * @param sigma0 Standard deviation of D0 (> 0)
+ * @param mu1 Mean of D1
+ * @param sigma1 Standard deviation of D1 (> 0)
+ * @param rho Correlation between D0 and D1
+ * @return Expression representing E[D0⁺ × D1⁺]
+ * 
+ * @note Implemented as a custom function for code clarity and consistency
+ */
 Expression expected_prod_pos_expr(const Expression& mu0, const Expression& sigma0,
                                   const Expression& mu1, const Expression& sigma1,
                                   const Expression& rho);


### PR DESCRIPTION
# Add Phi2_expr function for consistent interface

## 概要

`PHI2`操作を直接作成する代わりに、`Phi2_expr`関数を追加して、他の統計関数と一貫したインターフェースを提供します。

## 変更内容

### 1. `Phi2_expr`関数の追加
- `statistical_functions.cpp`に`Phi2_expr`関数を実装
- `statistical_functions.hpp`に宣言を追加
- 他の統計関数（`phi_expr`, `Phi_expr`など）と一貫したインターフェースを提供

### 2. `expected_prod_pos_expr`内での使用
- `PHI2`ノードの直接作成を`Phi2_expr`呼び出しに変更
- コードの一貫性を向上

## 実装の詳細

`Phi2_expr`は`PHI2`ノードを作成するラッパー関数です。`bivariate_normal_cdf`が数値積分（Simpson's rule）を使用するため、Expressionツリーとして直接表現できません。そのため、`PHI2`操作を内部で使用しています。

```cpp
Expression Phi2_expr(const Expression& h, const Expression& k, const Expression& rho) {
    // Φ₂(h, k; ρ) = Bivariate normal CDF
    // Create PHI2 node directly - it handles numerical integration internally
    return Expression(std::make_shared<ExpressionImpl>(ExpressionImpl::PHI2, h, k, rho));
}
```

## テスト結果

- すべてのテストが成功（50件の共分散テスト + 8件の統合テスト）
- コンパイルエラーなし
- 既存の機能に影響なし

## 今後の検討事項

`PHI2`操作を完全にカスタム関数で置き換えるには、数値積分をExpressionツリーで表現する必要がありますが、現時点では実装が困難です。現状の実装で、コードの一貫性は向上しています。

## 関連Issue

この変更は、統計関数の一貫性向上のためのリファクタリングです。
