### PR TITLE
refactor: Replace PHI2 operation with Native custom function

### DIFF
--- a/src/expression.hpp
+++ b/src/expression.hpp
@@ -174,7 +174,7 @@ class ExpressionImpl : public std::enable_shared_from_this<ExpressionImpl> {
     // print all expression infomation
     friend void print_all();
 
-    enum Op { CONST = 0, PARAM, PLUS, MINUS, MUL, DIV, POWER, EXP, LOG, ERF, SQRT, PHI2, CUSTOM_FUNCTION };
+    enum Op { CONST = 0, PARAM, PLUS, MINUS, MUL, DIV, POWER, EXP, LOG, ERF, SQRT, CUSTOM_FUNCTION };
 
     static void print_all();
     void print();
@@ -183,10 +183,6 @@ class ExpressionImpl : public std::enable_shared_from_this<ExpressionImpl> {
     ExpressionImpl(double value);
 
     ExpressionImpl(const Op& op, const Expression& left, const Expression& right);
-
-    // Constructor for 3-argument operations (e.g., PHI2)
-    ExpressionImpl(const Op& op, const Expression& first, const Expression& second,
-                   const Expression& third);
 
     // Constructor for CUSTOM_FUNCTION operation
     ExpressionImpl(const CustomFunctionHandle& func,
@@ -218,9 +214,6 @@ class ExpressionImpl : public std::enable_shared_from_this<ExpressionImpl> {
     }
     [[nodiscard]] const Expression& right() const {
         return right_;
-    }
-    [[nodiscard]] const Expression& third() const {
-        return third_;
     }
     [[nodiscard]] const std::vector<Expression>& custom_args() const {
         return custom_args_;
@@ -257,7 +250,6 @@ class ExpressionImpl : public std::enable_shared_from_this<ExpressionImpl> {
                    // type, const is intentional
     Expression left_;
     Expression right_;
-    Expression third_;  // For 3-argument operations (e.g., PHI2: h, k, rho)
     Expressions roots_;
 
     // Custom function fields (only valid when op_ == CUSTOM_FUNCTION)

--- a/src/statistical_functions.hpp
+++ b/src/statistical_functions.hpp
@@ -145,9 +145,8 @@ Expression max0_var_expr(const Expression& mu, const Expression& sigma);
  * @param rho Correlation coefficient
  * @return Expression representing Φ₂(h, k; ρ)
  * 
- * @note Uses PHI2 operation internally for numerical integration.
- *       This function provides a consistent interface similar to other
- *       statistical functions.
+ * @note Implemented as a Native type custom function for better consistency
+ *       with other statistical functions.
  */
 Expression Phi2_expr(const Expression& h, const Expression& k, const Expression& rho);
 

--- a/test/test_expression_helpers.cpp
+++ b/test/test_expression_helpers.cpp
@@ -44,9 +44,9 @@ static std::unordered_map<Phi2CacheKey, Expression, Phi2CacheKeyHash> phi2_expr_
 
 // Bivariate standard normal CDF Φ₂(h, k; ρ)
 // NOTE: This function is for testing purposes only.
-// In production code, expected_prod_pos_expr() in expression.cpp creates PHI2 node directly.
+// In production code, Phi2_expr() uses Native type custom function.
 Expression Phi2_expr_test(const Expression& h, const Expression& k, const Expression& rho) {
-    // Φ₂(h, k; ρ) using numerical integration for value, analytical gradients
+    // Φ₂(h, k; ρ) - use production Phi2_expr which now uses Native custom function
     
     // Check cache first
     auto key = std::make_tuple(h.get(), k.get(), rho.get());
@@ -55,7 +55,8 @@ Expression Phi2_expr_test(const Expression& h, const Expression& k, const Expres
         return it->second;
     }
     
-    Expression result = Expression(std::make_shared<ExpressionImpl>(ExpressionImpl::PHI2, h, k, rho));
+    // Use production Phi2_expr (now implemented as Native custom function)
+    Expression result = RandomVariable::Phi2_expr(h, k, rho);
     
     // Cache the result
     phi2_expr_cache[key] = result;


### PR DESCRIPTION
# Replace PHI2 operation with Native custom function

## 概要

PHI2の3項演算をNative型カスタム関数に置き換え、コードを簡素化しました。

## 変更内容

### 1. Phi2_exprをNative型カスタム関数として実装
- `bivariate_normal_cdf`で値を計算
- 勾配公式で勾配を計算：
  - ∂Φ₂/∂h = φ(h) × Φ((k - ρh)/√(1-ρ²))
  - ∂Φ₂/∂k = φ(k) × Φ((h - ρk)/√(1-ρ²))
  - ∂Φ₂/∂ρ = φ₂(h, k; ρ) (bivariate normal PDF)

### 2. expression.cppからPHI2オペレーションを削除
- `value()`メソッドからPHI2処理を削除
- `propagate_gradient()`メソッドからPHI2処理を削除
- `print()`メソッドからPHI2表示を削除

### 3. PHI2 enum定数を削除
- `ExpressionImpl::Op`から`PHI2`を削除
- 3項演算の特殊処理が不要になったため

### 4. third_フィールドと3引数コンストラクタを削除
- `third_`フィールドを削除
- 3引数コンストラクタを削除
- `third()`メソッドを削除
- デストラクタ、DFS、ノード収集から`third()`の参照を削除

### 5. テストの更新
- `Phi2_expr_test`を`Phi2_expr`を使うように変更
- すべてのテストが成功

## 利点

1. **コードの簡素化**: 3項演算の特殊処理が不要になり、コードが簡潔に
2. **一貫性**: 他の統計関数と同様にNative型カスタム関数として実装
3. **保守性**: 特殊ケースが減り、保守が容易に
4. **拡張性**: 将来の3項演算が必要な場合も、カスタム関数で対応可能

## テスト結果

すべてのテストが成功（719件）:
- Phi2関連テスト: 16件
- CovMax0Max0関連テスト: 35件
- その他のテスト: 668件

## 関連PR

- #200: Native型カスタム関数機能の追加（このPRの基盤）
