### PR TITLE
fix: Use sensitivity tolerance for sensitivity analysis tests

### DIFF
--- a/example/compare_numerical.py
+++ b/example/compare_numerical.py
@@ -32,7 +32,7 @@ def compare_values(val1_str, val2_str, tol):
     except ValueError:
         return False
 
-def compare_lines(line1, line2, lat_tol, corr_tol, max_errors):
+def compare_lines(line1, line2, lat_tol, corr_tol, sens_tol, max_errors):
     """Compare two lines with numerical tolerance.
     
     Args:
@@ -40,7 +40,8 @@ def compare_lines(line1, line2, lat_tol, corr_tol, max_errors):
         line2: Second line to compare
         lat_tol: Tolerance for LAT values (mean, stddev) - relative error
         corr_tol: Tolerance for correlation values - relative error
-        max_errors: Dictionary to track maximum errors {'lat': max_lat_error, 'corr': max_corr_error}
+        sens_tol: Tolerance for sensitivity values (dF/dmu, dF/dsigma) - relative error
+        max_errors: Dictionary to track maximum errors {'lat': max_lat_error, 'corr': max_corr_error, 'sens': max_sens_error}
     """
     if line1 == line2:
         return True
@@ -72,7 +73,8 @@ def compare_lines(line1, line2, lat_tol, corr_tol, max_errors):
     # - Lines without tabs → LAT values (or sensitivity values)
     is_correlation_line = '\t' in line1 or '\t' in line2
     
-    # Split by whitespace (both space and tab)
+    # Check if this is a sensitivity line (contains "dF/dmu" or "dF/dsigma" header, or has 6+ fields with numeric values)
+    # Sensitivity lines have format: instance output input type dF/dmu dF/dsigma
     fields1 = re.split(r'[ \t]+', line1.strip())
     fields2 = re.split(r'[ \t]+', line2.strip())
     
@@ -80,10 +82,19 @@ def compare_lines(line1, line2, lat_tol, corr_tol, max_errors):
     fields1 = [f for f in fields1 if f]
     fields2 = [f for f in fields2 if f]
     
+    # Check if this is a sensitivity line:
+    # - Has 6+ fields
+    # - Last two fields are numeric (dF/dmu, dF/dsigma)
+    # - Not a correlation line (no tabs)
+    is_sensitivity_line = (not is_correlation_line and 
+                           len(fields1) >= 6 and len(fields2) >= 6 and
+                           is_numeric(fields1[-1]) and is_numeric(fields1[-2]) and
+                           is_numeric(fields2[-1]) and is_numeric(fields2[-2]))
+    
     if len(fields1) != len(fields2):
         return False
     
-    for f1, f2 in zip(fields1, fields2):
+    for idx, (f1, f2) in enumerate(zip(fields1, fields2)):
         if is_numeric(f1) and is_numeric(f2):
             val1 = float(f1)
             val2 = float(f2)
@@ -94,12 +105,18 @@ def compare_lines(line1, line2, lat_tol, corr_tol, max_errors):
             if abs(val1) > 1e-10 and abs(val2) > 1e-10:
                 rel_err = diff / max(abs(val1), abs(val2))
             
-            # Use tolerance based on line format (tab = correlation)
+            # Determine tolerance based on line type
             if is_correlation_line:
                 tol = corr_tol
                 if rel_err > max_errors['corr']:
                     max_errors['corr'] = rel_err
+            elif is_sensitivity_line and idx >= len(fields1) - 2:
+                # Last two fields are sensitivity values (dF/dmu, dF/dsigma)
+                tol = sens_tol
+                if rel_err > max_errors['sens']:
+                    max_errors['sens'] = rel_err
             else:
+                # LAT values (mean, stddev, score, objective, etc.)
                 tol = lat_tol
                 if rel_err > max_errors['lat']:
                     max_errors['lat'] = rel_err
@@ -114,18 +131,20 @@ def compare_lines(line1, line2, lat_tol, corr_tol, max_errors):
 
 def main():
     if len(sys.argv) < 4:
-        print("Usage: compare_numerical.py <file1> <file2> <lat_tolerance> [corr_tolerance]", file=sys.stderr)
+        print("Usage: compare_numerical.py <file1> <file2> <lat_tolerance> [corr_tolerance] [sens_tolerance]", file=sys.stderr)
         print("  lat_tolerance: Tolerance for LAT values (mean, stddev) - relative error (default: 0.002 = 0.2%)", file=sys.stderr)
         print("  corr_tolerance: Tolerance for correlation values - relative error (default: 0.032 = 3.2%)", file=sys.stderr)
+        print("  sens_tolerance: Tolerance for sensitivity values (dF/dmu, dF/dsigma) - relative error (default: 0.02 = 2.0%)", file=sys.stderr)
         sys.exit(1)
     
     file1 = sys.argv[1]
     file2 = sys.argv[2]
     lat_tol = float(sys.argv[3])
     corr_tol = float(sys.argv[4]) if len(sys.argv) > 4 else 0.032  # Default 3.2%
+    sens_tol = float(sys.argv[5]) if len(sys.argv) > 5 else 0.02  # Default 2.0%
     
     # Track maximum errors
-    max_errors = {'lat': 0.0, 'corr': 0.0}
+    max_errors = {'lat': 0.0, 'corr': 0.0, 'sens': 0.0}
     all_passed = True
     
     try:
@@ -134,17 +153,17 @@ def main():
             lines2 = f2.readlines()
             
             if len(lines1) != len(lines2):
-                print(f"MAX_LAT_ERROR:N/A MAX_CORR_ERROR:N/A (line count mismatch: {len(lines1)} vs {len(lines2)})")
+                print(f"MAX_LAT_ERROR:N/A MAX_CORR_ERROR:N/A MAX_SENS_ERROR:N/A (line count mismatch: {len(lines1)} vs {len(lines2)})")
                 sys.exit(1)
             
             for l1, l2 in zip(lines1, lines2):
-                if not compare_lines(l1, l2, lat_tol, corr_tol, max_errors):
+                if not compare_lines(l1, l2, lat_tol, corr_tol, sens_tol, max_errors):
                     all_passed = False
                     # Continue to collect all errors instead of exiting early
         
         # Always output maximum errors to stdout (for parsing by shell script)
-        # Format: MAX_LAT_ERROR:0.001234 MAX_CORR_ERROR:0.023456
-        print(f"MAX_LAT_ERROR:{max_errors['lat']:.6f} MAX_CORR_ERROR:{max_errors['corr']:.6f}")
+        # Format: MAX_LAT_ERROR:0.001234 MAX_CORR_ERROR:0.023456 MAX_SENS_ERROR:0.001234
+        print(f"MAX_LAT_ERROR:{max_errors['lat']:.6f} MAX_CORR_ERROR:{max_errors['corr']:.6f} MAX_SENS_ERROR:{max_errors['sens']:.6f}")
         sys.exit(0 if all_passed else 1)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/example/nhssta_test
+++ b/example/nhssta_test
@@ -10,11 +10,13 @@ FAILED_TESTS=0
 # Tolerance for floating-point comparisons (relative error)
 # LAT values (mean, stddev): 1.6% (0.016) - actual max error is ~1.33% in large circuits
 # Correlation values: 3.8% (0.038) - actual max error is ~3.12%
+# Sensitivity values (dF/dmu, dF/dsigma): 2.0% (0.02) - gradient values typically have small errors
 # MAX operation is commutative, so different calculation order causes small differences
 # LAT values typically have smaller errors (~0.07-0.41% in small circuits, up to ~1.33% in large circuits)
 # Correlation values can accumulate more error due to multiple MAX operations (up to ~3.12%)
 LAT_TOLERANCE=0.016
 CORR_TOLERANCE=0.038
+SENS_TOLERANCE=0.02
 
 # Function to print section header
 print_section() {
@@ -181,13 +183,14 @@ run_test() {
     fi
 
     # Compare with expected result using numerical tolerance
-    # LAT tolerance: 1.6%, Correlation tolerance: 3.8%
-    COMPARE_OUTPUT=$(python3 compare_numerical.py "${TEMP_RESULT_FILE}" "${RESULT_FILE}" "${LAT_TOLERANCE}" "${CORR_TOLERANCE}" 2>/dev/null)
+    # LAT tolerance: 1.6%, Correlation tolerance: 3.8%, Sensitivity tolerance: 2.0%
+    COMPARE_OUTPUT=$(python3 compare_numerical.py "${TEMP_RESULT_FILE}" "${RESULT_FILE}" "${LAT_TOLERANCE}" "${CORR_TOLERANCE}" "${SENS_TOLERANCE}" 2>/dev/null)
     COMPARE_EXIT_CODE=$?
     
     # Extract maximum errors from output using awk (compatible with macOS)
     MAX_LAT_ERROR=$(echo "${COMPARE_OUTPUT}" | awk -F'MAX_LAT_ERROR:' '{print $2}' | awk '{print $1}' | awk -F'MAX_CORR_ERROR:' '{print $1}')
-    MAX_CORR_ERROR=$(echo "${COMPARE_OUTPUT}" | awk -F'MAX_CORR_ERROR:' '{print $2}')
+    MAX_CORR_ERROR=$(echo "${COMPARE_OUTPUT}" | awk -F'MAX_CORR_ERROR:' '{print $2}' | awk '{print $1}' | awk -F'MAX_SENS_ERROR:' '{print $1}')
+    MAX_SENS_ERROR=$(echo "${COMPARE_OUTPUT}" | awk -F'MAX_SENS_ERROR:' '{print $2}')
     
     # Default to 0.0 if extraction failed
     if [ -z "${MAX_LAT_ERROR}" ] || [ "${MAX_LAT_ERROR}" = "" ]; then
@@ -196,21 +199,40 @@ run_test() {
     if [ -z "${MAX_CORR_ERROR}" ] || [ "${MAX_CORR_ERROR}" = "" ]; then
         MAX_CORR_ERROR="0.000000"
     fi
+    if [ -z "${MAX_SENS_ERROR}" ] || [ "${MAX_SENS_ERROR}" = "" ]; then
+        MAX_SENS_ERROR="0.000000"
+    fi
     
     # Convert to percentage
     MAX_LAT_PCT=$(echo "${MAX_LAT_ERROR}" | awk '{printf "%.2f", $1 * 100}')
     MAX_CORR_PCT=$(echo "${MAX_CORR_ERROR}" | awk '{printf "%.2f", $1 * 100}')
+    MAX_SENS_PCT=$(echo "${MAX_SENS_ERROR}" | awk '{printf "%.2f", $1 * 100}')
     
     # Calculate tolerance percentages
     LAT_TOL_PCT=$(echo "${LAT_TOLERANCE}" | awk '{printf "%.2f", $1 * 100}')
     CORR_TOL_PCT=$(echo "${CORR_TOLERANCE}" | awk '{printf "%.2f", $1 * 100}')
+    SENS_TOL_PCT=$(echo "${SENS_TOLERANCE}" | awk '{printf "%.2f", $1 * 100}')
+    
+    # Determine if this is a sensitivity test
+    IS_SENSITIVITY_TEST=false
+    if echo "${OPTIONS}" | grep -q "\-s"; then
+        IS_SENSITIVITY_TEST=true
+    fi
     
     if [ ${COMPARE_EXIT_CODE} -eq 0 ]; then
-        print_success "  ✓ PASSED (最大誤差: LAT ${MAX_LAT_PCT}%, 相関 ${MAX_CORR_PCT}%)"
+        if [ "${IS_SENSITIVITY_TEST}" = "true" ]; then
+            print_success "  ✓ PASSED (最大誤差: 感度 ${MAX_SENS_PCT}%)"
+        else
+            print_success "  ✓ PASSED (最大誤差: LAT ${MAX_LAT_PCT}%, 相関 ${MAX_CORR_PCT}%)"
+        fi
         PASSED_TESTS=$((PASSED_TESTS + 1))
         rm -f "${TEMP_RESULT_FILE}" # Clean up on success
     else
-        print_failure "  ✗ FAILED (最大誤差: LAT ${MAX_LAT_PCT}%, 相関 ${MAX_CORR_PCT}%, 許容: LAT ${LAT_TOL_PCT}%, 相関 ${CORR_TOL_PCT}%)"
+        if [ "${IS_SENSITIVITY_TEST}" = "true" ]; then
+            print_failure "  ✗ FAILED (最大誤差: 感度 ${MAX_SENS_PCT}%, 許容: 感度 ${SENS_TOL_PCT}%)"
+        else
+            print_failure "  ✗ FAILED (最大誤差: LAT ${MAX_LAT_PCT}%, 相関 ${MAX_CORR_PCT}%, 許容: LAT ${LAT_TOL_PCT}%, 相関 ${CORR_TOL_PCT}%)"
+        fi
         echo "    --- Diff for ${TEST_NAME} ---"
         # Show diff for debugging, but use numerical comparison for pass/fail
         diff -u "${TEMP_RESULT_FILE}" "${RESULT_FILE}" | head -30


### PR DESCRIPTION
## 概要

感度解析テストで、LAT/相関の誤差ではなく感度値（dF/dmu, dF/dsigma）の誤差を確認するように修正しました。

## 問題点

感度解析テストでは、LATや相関の誤差ではなく、感度値（∂F/∂μ, ∂F/∂σ）の誤差を確認すべきでしたが、従来のLAT/相関の許容誤差で比較していました。

## 修正内容

### 1. `compare_numerical.py`の修正
- 感度解析の出力を識別: `dF/dmu`, `dF/dsigma`を含む行を検出
- 感度値に専用の許容誤差を適用: `sens_tol`パラメータを追加（デフォルト2.0%）
- `max_errors`辞書に`sens`キーを追加
- 出力フォーマットに`MAX_SENS_ERROR`を追加

### 2. `nhssta_test`スクリプトの修正
- `SENS_TOLERANCE=0.02`（2.0%）を追加
- `compare_numerical.py`に感度許容誤差を渡すように修正
- 感度解析テストの場合、出力メッセージを「最大誤差: 感度 X.XX%」に変更
- 通常のテストは従来通り「最大誤差: LAT X.XX%, 相関 X.XX%」を表示

## テスト結果

すべてのテストが成功:
- 通常テスト（8件）: 「最大誤差: LAT X.XX%, 相関 X.XX%」と表示
- 感度解析テスト（2件）: 「最大誤差: 感度 0.00%」と表示

## 関連Issue

なし（バグ修正）