### PR TITLE
docs: Fix README.md sensitivity analysis example to match actual output

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,20 +226,26 @@ nhssta 0.3.2
 #
 # Sensitivity Analysis
 #
-# Objective: log(Σ exp(LAT + σ)) = 22.15
+# Objective: log(Σ exp(LAT + σ)) = 94.688
 #
-# Top 5 Endpoints (by LAT + σ):
+# Top 1 Endpoints (by LAT + σ):
 #
 #node                    LAT    sigma     score
 #-----------------------------------------
-...
+Y                     89.770    4.923    94.693
 #-----------------------------------------
 #
 # Gate Sensitivities (∂F/∂μ, ∂F/∂σ):
 #
 #instance   output    input   type          dF/dmu   dF/dsigma
 #-------------------------------------------------------------
-...
+inv:0       N2        B       inv         1.000766    0.399863
+and:0       Y         N3      and         0.708390    0.597047
+nand:0      N1        N2      nand        0.706665    0.447726
+inv:1       N3        N1      inv         0.708390    0.298523
+and:0       Y         N4      and         0.291610    0.346626
+or:0        N4        N2      or          0.294101    0.293807
+nand:0      N1        A       nand        0.001725    0.005387
 #-------------------------------------------------------------
 OK
 ```


### PR DESCRIPTION
## 概要

README.mdの感度解析の出力例を実装の実際の出力と一致するように修正しました。

## 問題点

README.mdの感度解析の出力例が実装の実際の出力と一致していませんでした：
- Objective値が22.15となっていたが、実際は94.688
- "Top 5 Endpoints"となっていたが、実際は"Top 1 Endpoints"（ex4.benchには1つのエンドポイントしかないため）
- 出力例が"..."で省略されていたが、実際の出力例を記載した方が分かりやすい

## 修正内容

- Objective値を22.15から94.688に更新
- "Top 5 Endpoints"を"Top 1 Endpoints"に更新（実装ではエンドポイント数に応じて動的に表示される）
- 出力例の"..."を実際の出力例に置き換え

## 確認

- 実装の実際の出力と一致することを確認
- lintエラーなし