### PR TITLE
Fix #213: 文字列変換のエラーハンドリング改善

### DIFF
--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -763,8 +763,11 @@ SensitivityResults Ssta::getSensitivityResults(size_t top_n) const {
                 if (pin_idx < input_signals.size()) {
                     input_signal = input_signals[pin_idx];
                 }
-            } catch (...) {
-                // Keep pin_name if not a number
+            } catch (const std::invalid_argument& e) {
+                // Keep pin_name if not a number (this is acceptable for non-numeric pin names)
+            } catch (const std::out_of_range& e) {
+                // Pin index out of range - this is an error condition
+                throw Nh::RuntimeException("Pin index out of range: " + pin_name);
             }
             
             // Get gradients from the cloned Expression

--- a/test/test_main_cli.cpp
+++ b/test/test_main_cli.cpp
@@ -236,12 +236,17 @@ TEST_F(CommandLineTest, TestCriticalPathShortOptionWithCount) {
         << "Critical path output should include LAT-style table header";
 }
 
-// Test: critical path option (--path invalid) falls back to default count
+// Test: critical path option (--path invalid) shows clear error message
 TEST_F(CommandLineTest, TestCriticalPathLongOptionInvalidArgument) {
     std::string output = run_nhssta(
         {"--path", "invalid", "-d", example_path("ex4_gauss.dlib"), "-b", example_path("ex4.bench")});
-    EXPECT_NE(output.find("usage"), std::string::npos)
-        << "Invalid numeric argument should currently be treated as an error";
+    // Should show error message about invalid number format
+    EXPECT_NE(output.find("error"), std::string::npos)
+        << "Invalid numeric argument should show error message. Got: " << output.substr(0, 300);
+    bool has_invalid_message = output.find("Invalid number format") != std::string::npos ||
+                                output.find("invalid") != std::string::npos;
+    EXPECT_TRUE(has_invalid_message)
+        << "Error message should mention invalid number format";
 }
 
 // Test: critical path option with negative count should trigger usage (treated as invalid flag)
@@ -332,4 +337,59 @@ TEST_F(CommandLineTest, TestSensitivityTopN) {
     // Both should contain sensitivity analysis
     EXPECT_NE(output_n2.find("Sensitivity Analysis"), std::string::npos);
     EXPECT_NE(output_n3.find("Sensitivity Analysis"), std::string::npos);
+}
+
+// Test: Invalid number format for -p option should show clear error message
+TEST_F(CommandLineTest, TestInvalidNumberFormatForPathOption) {
+    std::string output = run_nhssta(
+        {"-p", "abc", "-d", example_path("ex4_gauss.dlib"), "-b", example_path("ex4.bench")});
+    
+    // Should show error message about invalid number format
+    EXPECT_NE(output.find("error"), std::string::npos)
+        << "Should show error message for invalid number format. Got: " << output.substr(0, 300);
+    bool has_invalid_message = output.find("Invalid number format") != std::string::npos ||
+                                output.find("invalid") != std::string::npos ||
+                                output.find("abc") != std::string::npos;
+    EXPECT_TRUE(has_invalid_message)
+        << "Error message should mention invalid number format or the invalid value";
+}
+
+// Test: Invalid number format (decimal) for -p option should show clear error message
+TEST_F(CommandLineTest, TestInvalidDecimalNumberFormatForPathOption) {
+    std::string output = run_nhssta(
+        {"-p", "12.34", "-d", example_path("ex4_gauss.dlib"), "-b", example_path("ex4.bench")});
+    
+    // Should show error message about invalid number format
+    EXPECT_NE(output.find("error"), std::string::npos)
+        << "Should show error message for invalid number format. Got: " << output.substr(0, 300);
+}
+
+// Test: Invalid number format for -n option should show clear error message
+TEST_F(CommandLineTest, TestInvalidNumberFormatForTopNOption) {
+    std::string output = run_nhssta(
+        {"-s", "-n", "xyz", "-d", example_path("ex4_gauss.dlib"), "-b", example_path("ex4.bench")});
+    
+    // Should show error message about invalid number format
+    EXPECT_NE(output.find("error"), std::string::npos)
+        << "Should show error message for invalid number format. Got: " << output.substr(0, 300);
+    bool has_invalid_message = output.find("Invalid number format") != std::string::npos ||
+                                output.find("invalid") != std::string::npos ||
+                                output.find("xyz") != std::string::npos;
+    EXPECT_TRUE(has_invalid_message)
+        << "Error message should mention invalid number format or the invalid value";
+}
+
+// Test: Out of range number for -p option should show clear error message
+TEST_F(CommandLineTest, TestOutOfRangeNumberForPathOption) {
+    // Use a number that exceeds size_t max value
+    std::string output = run_nhssta(
+        {"-p", "999999999999999999999999999", "-d", example_path("ex4_gauss.dlib"), "-b", example_path("ex4.bench")});
+    
+    // Should show error message about number out of range
+    EXPECT_NE(output.find("error"), std::string::npos)
+        << "Should show error message for out of range number. Got: " << output.substr(0, 300);
+    bool has_range_message = output.find("out of range") != std::string::npos ||
+                             output.find("range") != std::string::npos;
+    EXPECT_TRUE(has_range_message)
+        << "Error message should mention out of range";
 }


### PR DESCRIPTION
## 概要

Issue #213で指摘された文字列変換のエラーハンドリング不足を修正しました。

## 変更内容

### 修正したファイル
- `src/main.cpp`: `parse_count()`関数のエラーハンドリングを改善
- `src/ssta.cpp`: `getSensitivityResults()`内の`std::stoul()`のエラーハンドリングを改善
- `test/test_main_cli.cpp`: テストケースを追加

### 実装詳細

1. **`parse_count()`関数の改善**
   - `std::invalid_argument`と`std::out_of_range`を個別にキャッチ
   - 適切な`ConfigurationException`を投げるように修正
   - 小数点を含む数値のチェックを追加（`std::stoul`は小数点以下を切り捨てるため）

2. **`ssta.cpp:762`の改善**
   - 範囲外の数値の場合のみエラーを投げるように修正
   - 数値でないピン名の場合は従来通りフォールバック動作を維持

3. **テストケースの追加**
   - 無効な数値形式（"abc"）のテスト
   - 小数点を含む数値（"12.34"）のテスト
   - 範囲外の数値のテスト
   - 既存のテストも新しい動作に合わせて更新

## テスト結果

- ✅ すべてのテストがパス（740テスト）
- ✅ 新しく追加した4つのテストケースもすべてパス

## 動作確認

無効な数値が渡された場合に、以下のような明確なエラーメッセージが表示されるようになりました：

```
error: Configuration error: Invalid number format: abc
```

```
error: Configuration error: Invalid number format: 12.34 (decimal numbers are not allowed)
```

```
error: Configuration error: Number out of range: 999999999999999999999999999
```

## 関連Issue

Closes #213