### PR TITLE
Fix #220: 非効率な文字列操作の改善

### DIFF
--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <nhssta/ssta.hpp>
 #include <nhssta/ssta_results.hpp>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -39,37 +40,34 @@ void Ssta::check() {
     // Validate configuration and throw exception if invalid
     // Error messages should be handled by CLI layer
 
-    std::string error_msg;
+    std::ostringstream error_msg;
 
     if (dlib_.empty()) {
-        if (!error_msg.empty()) {
-            error_msg += "; ";
+        if (error_msg.tellp() > 0) {
+            error_msg << "; ";
         }
-        error_msg += "please specify `-d' properly";
+        error_msg << "please specify `-d' properly";
     }
 
     if (bench_.empty()) {
-        if (!error_msg.empty()) {
-            error_msg += "; ";
+        if (error_msg.tellp() > 0) {
+            error_msg << "; ";
         }
-        error_msg += "please specify `-b' properly";
+        error_msg << "please specify `-b' properly";
     }
 
-    if (!error_msg.empty()) {
-        throw Nh::ConfigurationException(error_msg);
+    std::string error_str = error_msg.str();
+    if (!error_str.empty()) {
+        throw Nh::ConfigurationException(error_str);
     }
 }
 
 //// read ////
 
 void Ssta::node_error(const std::string& head, const std::string& signal_name) const {
-    std::string what(head);
-    what += " \"";
-    what += signal_name;
-    what += "\" is multiply defined in file \"";
-    what += bench_;
-    what += "\"";
-    throw Nh::RuntimeException(what);
+    std::ostringstream what;
+    what << head << " \"" << signal_name << "\" is multiply defined in file \"" << bench_ << "\"";
+    throw Nh::RuntimeException(what.str());
 }
 
 // dlib //
@@ -254,10 +252,9 @@ void Ssta::connect_instances() {
                 const std::string& gate_name = line->gate();
                 auto gi = gates_.find(gate_name);
                 if (gi == gates_.end()) {
-                    std::string what = "gate \"";
-                    what += gate_name;
-                    what += "\" not found in gate library";
-                    throw Nh::RuntimeException(what);
+                    std::ostringstream what;
+                    what << "gate \"" << gate_name << "\" not found in gate library";
+                    throw Nh::RuntimeException(what.str());
                 }
 
                 Gate gate = gi->second;
@@ -285,14 +282,14 @@ void Ssta::connect_instances() {
 
         // floating circuit
         if (size == net_.size()) {
-            std::string what = "following node is floating\n";
+            std::ostringstream what;
+            what << "following node is floating\n";
             ni = net_.begin();
             for (; ni != net_.end(); ni++) {
                 const NetLine& line = *ni;
-                what += line->out();
-                what += "\n";
+                what << line->out() << "\n";
             }
-            throw Nh::RuntimeException(what);
+            throw Nh::RuntimeException(what.str());
         }
     }
 }


### PR DESCRIPTION
## 概要

Issue #220で指摘された非効率な文字列操作を改善しました。

## 変更内容

### 修正したファイル
- `src/ssta.cpp`: 文字列連結を`+=`から`std::ostringstream`に変更

### 実装詳細

以下の4箇所で`+=`による文字列連結を`std::ostringstream`に置き換えました：

1. **`check()`関数**（42-60行目）
   - エラーメッセージの構築を`ostringstream`に変更
   - `error_msg.empty()`の代わりに`error_msg.tellp() > 0`を使用

2. **`node_error()`関数**（65-73行目）
   - エラーメッセージの構築を`ostringstream`に変更
   - 5回の`+=`操作を1回の`<<`操作に統合

3. **`connect_instances()`関数 - gate not found**（257-260行目）
   - エラーメッセージの構築を`ostringstream`に変更
   - 3回の`+=`操作を1回の`<<`操作に統合

4. **`connect_instances()`関数 - floating circuit**（288-295行目）
   - エラーメッセージの構築を`ostringstream`に変更
   - ループ内の`+=`操作を`<<`操作に変更

### 追加したヘッダー
- `<sstream>`: `std::ostringstream`を使用するために追加

## テスト結果

- ✅ すべてのテストがパス（744テスト）
- ✅ 既存のエラーメッセージのテストもすべてパス

## パフォーマンスへの影響

`std::ostringstream`を使用することで：

- **メモリ再割り当ての頻度が減少**: `ostringstream`は内部バッファを効率的に管理し、複数の文字列を連結する際にメモリ再割り当てが発生しにくくなります
- **コードの可読性が向上**: `<<`演算子による連結は、`+=`よりも読みやすく、意図が明確になります
- **特に効果的なケース**: 複数の文字列を連結する場合（例: `node_error()`関数）に効果的です

## 関連Issue

Closes #220