### PR TITLE
Fix #216: エラーメッセージの一貫性の改善

### DIFF
--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <nhssta/exception.hpp>
+#include <sstream>
 #include <string>
 
 #include "add.hpp"
@@ -44,14 +45,9 @@ const Normal& GateImpl::delay(const std::string& in, const std::string& out) con
 
     auto i = delays_.find(io);
     if (i == delays_.end()) {
-        std::string what = "delay from pin \"";
-        what += in;
-        what += "\" to pin \"";
-        what += out;
-        what += "\" is not set on gate \"";
-        what += type_name();
-        what += "\"";
-        throw Nh::RuntimeException(what);
+        std::ostringstream what;
+        what << "Delay from pin \"" << in << "\" to pin \"" << out << "\" is not set on gate \"" << type_name() << "\"";
+        throw Nh::RuntimeException(what.str());
     }
 
     return i->second;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,15 +37,15 @@ size_t parse_count(int argc, char* argv[], int& i, size_t default_value) {
             try {
                 // Check if the string contains a decimal point (invalid for unsigned integer)
                 if (next_arg.find('.') != std::string::npos) {
-                    throw Nh::ConfigurationException("Invalid number format: " + next_arg + " (decimal numbers are not allowed)");
+                    throw Nh::ConfigurationException("Invalid number format: \"" + next_arg + "\" (decimal numbers are not allowed)");
                 }
                 auto count = static_cast<size_t>(std::stoul(next_arg));
                 i++;  // Consume the number argument
                 return count;
             } catch (const std::invalid_argument& e) {
-                throw Nh::ConfigurationException("Invalid number format: " + next_arg);
+                throw Nh::ConfigurationException("Invalid number format: \"" + next_arg + "\"");
             } catch (const std::out_of_range& e) {
-                throw Nh::ConfigurationException("Number out of range: " + next_arg);
+                throw Nh::ConfigurationException("Number out of range: \"" + next_arg + "\"");
             } catch (const Nh::ConfigurationException&) {
                 // Re-throw ConfigurationException
                 throw;

--- a/src/ssta.cpp
+++ b/src/ssta.cpp
@@ -253,7 +253,7 @@ void Ssta::connect_instances() {
                 auto gi = gates_.find(gate_name);
                 if (gi == gates_.end()) {
                     std::ostringstream what;
-                    what << "gate \"" << gate_name << "\" not found in gate library";
+                    what << "Gate \"" << gate_name << "\" not found in gate library";
                     throw Nh::RuntimeException(what.str());
                 }
 


### PR DESCRIPTION
## 概要

Issue #216で指摘されたエラーメッセージの一貫性の欠如を改善しました。

## 変更内容

### 修正したファイル
- `src/gate.cpp`: delay()のエラーメッセージを`ostringstream`に変更し、フォーマットを統一
- `src/ssta.cpp`: gate not foundのエラーメッセージの先頭を大文字に統一
- `src/main.cpp`: エラーメッセージの値部分を引用符で囲むように統一

### 実装詳細

1. **`src/gate.cpp`の改善**
   - `delay()`関数のエラーメッセージを`+=`から`ostringstream`に変更
   - メッセージの先頭を大文字に統一（`"delay"` → `"Delay"`）
   - フォーマットを統一: `"Delay from pin \"...\" to pin \"...\" is not set on gate \"...\""`

2. **`src/ssta.cpp`の改善**
   - gate not foundのエラーメッセージの先頭を大文字に統一（`"gate"` → `"Gate"`）

3. **`src/main.cpp`の改善**
   - エラーメッセージの値部分を引用符で囲むように統一
   - `"Invalid number format: " + next_arg` → `"Invalid number format: \"" + next_arg + "\""`
   - `"Number out of range: " + next_arg` → `"Number out of range: \"" + next_arg + "\""`

### 追加したヘッダー
- `src/gate.cpp`: `<sstream>`を追加（`ostringstream`を使用するため）

## テスト結果

- ✅ すべてのテストがパス（744テスト）
- ✅ 既存のエラーメッセージのテストもすべてパス

## 影響

- **エラーメッセージの一貫性が向上**: すべてのエラーメッセージで、エンティティ名や値は引用符で囲み、一貫した構造になりました
- **ユーザビリティの向上**: エラーメッセージが統一されたフォーマットになり、ユーザーにとって分かりやすくなりました
- **コードの可読性が向上**: `ostringstream`を使用することで、文字列連結がより明確になりました

## 統一されたフォーマット

- エンティティ名や値は引用符で囲む: `"entity_name"`
- エラーメッセージの先頭は大文字で始める: `"Delay..."`, `"Gate..."`
- 一貫した構造: `"Entity description: \"value\""`

## 関連Issue

Closes #216