### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 統計的PERT法 nhssta 0.3.2
+# 統計的PERT法 nhssta 0.3.3
 
-本ドキュメントには統計的PERT法 nhssta 0.3.2 (以下、nhssta ) の概要、使用方法、及び使用上の注意点が記載されています。
+本ドキュメントには統計的PERT法 nhssta 0.3.3 (以下、nhssta ) の概要、使用方法、及び使用上の注意点が記載されています。
 
 ## 1. 概要
 
@@ -108,8 +108,8 @@ $ make test
 すべてのテストがパスすると、以下のように表示されます：
 
 ```
-[==========] Running 719 tests from 64 test suites.
-[  PASSED  ] 719 tests.
+[==========] Running 781 tests from 70 test suites.
+[  PASSED  ] 781 tests.
 ==========================================
 Running integration tests...
 ==========================================
@@ -195,7 +195,7 @@ nhsstaは以下のexit codeを返します：
 # exampleディレクトリから実行する場合
 $ cd example
 $ ../build/bin/nhssta -l -c -p -d ex4_gauss.dlib -b ex4.bench
-nhssta 0.3.2
+nhssta 0.3.3
 
 #
 # LAT
@@ -221,7 +221,7 @@ OK
 
 ```bash
 $ ../build/bin/nhssta -s -n 5 -d ex4_gauss.dlib -b ex4.bench
-nhssta 0.3.2
+nhssta 0.3.3
 
 #
 # Sensitivity Analysis

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,7 +180,7 @@ std::string get_version_string() {
 #endif
     
     std::ostringstream oss;
-    oss << "nhssta 0.3.2 (";
+    oss << "nhssta 0.3.3 (";
     oss << std::put_time(&timeinfo, "%a %b %d %H:%M:%S %Y");
     oss << ")";
     return oss.str();

--- a/test/README.md
+++ b/test/README.md
@@ -67,7 +67,7 @@ Tests are compiled into a single test binary:
 
 ## Current Test Coverage
 
-- **485 tests** across **50 test suites**
+- **781 tests** across **70 test suites**
 - Unit tests for core components (RandomVariable, Gate, Parser, Ssta)
 - Expression tests (将来の感度解析機能用)
 - Integration tests for end-to-end functionality


### PR DESCRIPTION
バージョンを0.3.3に更新しました。

## 変更内容
- バージョン番号を0.3.2から0.3.3に更新
  - `src/main.cpp`: バージョン文字列を更新
  - `README.md`: ドキュメント内のバージョン番号を更新（4箇所）
- テスト数の更新
  - `README.md`: 719 tests from 64 test suites → 781 tests from 70 test suites
  - `test/README.md`: 485 tests across 50 test suites → 781 tests across 70 test suites

実装とREADMEの乖離を修正しました。